### PR TITLE
Create libkern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashmap_core 0.1.9 (git+https://github.com/pepyakin/hashmap_core?rev=add-alloc-layout-extra)",
+ "kfs-libkern 0.1.0",
  "kfs-libutils 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -139,6 +140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kfs-libkern"
+version = "0.1.0"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kfs-libutils 0.1.0",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kfs-libuser"
 version = "0.1.0"
 dependencies = [
@@ -146,6 +156,7 @@ dependencies = [
  "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kfs-libkern 0.1.0",
  "kfs-libutils 0.1.0",
  "linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashmap_core 0.1.9 (git+https://github.com/pepyakin/hashmap_core?rev=add-alloc-layout-extra)",
- "kfs-utils 0.1.0",
+ "kfs-libutils 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -146,9 +146,18 @@ dependencies = [
  "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kfs-utils 0.1.0",
+ "kfs-libutils 0.1.0",
  "linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kfs-libutils"
+version = "0.1.0"
+dependencies = [
+ "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -173,15 +182,6 @@ dependencies = [
  "kfs-libuser 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kfs-utils"
-version = "0.1.0"
-dependencies = [
- "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,8 +110,8 @@ version = "0.1.0"
 dependencies = [
  "font-rs 0.1.3 (git+https://github.com/orycterope/font-rs)",
  "hashmap_core 0.1.9 (git+https://github.com/pepyakin/hashmap_core?rev=add-alloc-layout-extra)",
+ "kfs-libuser 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libuser 0.1.0",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -139,6 +139,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kfs-libuser"
+version = "0.1.0"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitfield 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kfs-utils 0.1.0",
+ "linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kfs-shell"
 version = "0.1.0"
 dependencies = [
@@ -146,8 +159,8 @@ dependencies = [
  "font-rs 0.1.3 (git+https://github.com/orycterope/font-rs)",
  "gif 0.10.0 (git+https://github.com/roblabla/image-gif)",
  "hashmap_core 0.1.9 (git+https://github.com/pepyakin/hashmap_core?rev=add-alloc-layout-extra)",
+ "kfs-libuser 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libuser 0.1.0",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -157,8 +170,8 @@ name = "kfs-sm"
 version = "0.1.0"
 dependencies = [
  "hashmap_core 0.1.9 (git+https://github.com/pepyakin/hashmap_core?rev=add-alloc-layout-extra)",
+ "kfs-libuser 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libuser 0.1.0",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -176,8 +189,8 @@ name = "kfs-vi"
 version = "0.1.0"
 dependencies = [
  "hashmap_core 0.1.9 (git+https://github.com/pepyakin/hashmap_core?rev=add-alloc-layout-extra)",
+ "kfs-libuser 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libuser 0.1.0",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -188,19 +201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "libuser"
-version = "0.1.0"
-dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitfield 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kfs-utils 0.1.0",
- "linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["kernel", "bootstrap", "shell", "libuser", "clock", "sm", "vi", "libutils"]
+members = ["kernel", "bootstrap", "shell", "libuser", "clock", "sm", "vi", "libutils", "libkern"]
 
 [profile.release]
 debug = true

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["roblabla <unfiltered@roblab.la>", "orycterope <tvermeilh@gmail.com>"]
 
 [dependencies]
-libuser = { path = "../libuser" }
+kfs-libuser = { path = "../libuser" }
 font-rs = { git = "https://github.com/orycterope/font-rs" }
 spin = "0.4"
 hashmap_core = "0.1.9"

--- a/clock/src/main.rs
+++ b/clock/src/main.rs
@@ -1,7 +1,7 @@
 #![feature(alloc, used)]
 #![no_std]
 
-extern crate libuser;
+extern crate kfs_libuser as libuser;
 #[macro_use]
 extern crate alloc;
 extern crate font_rs;

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,6 +9,7 @@ sysroot_path = "target/sysroot"
 
 [dependencies]
 kfs-libutils = { path = "../libutils" }
+kfs-libkern = { path = "../libkern" }
 bit_field = "0.9.0"
 bitflags = "1.0"
 multiboot2 = { git = "https://github.com/roblabla/multiboot2-elf64" }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,7 +8,7 @@ memcpy = true
 sysroot_path = "target/sysroot"
 
 [dependencies]
-kfs-utils = { path = "../libutils" }
+kfs-libutils = { path = "../libutils" }
 bit_field = "0.9.0"
 bitflags = "1.0"
 multiboot2 = { git = "https://github.com/roblabla/multiboot2-elf64" }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -38,6 +38,7 @@ extern crate byteorder;
 extern crate failure;
 #[macro_use]
 extern crate bitfield;
+extern crate kfs_libkern;
 
 use core::fmt::Write;
 use alloc::prelude::*;

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -1,7 +1,7 @@
 //! Generic useful functions
 
-extern crate kfs_utils;
-pub use self::kfs_utils::*;
+extern crate kfs_libutils;
+pub use self::kfs_libutils::*;
 pub use checks::*;
 use error::KernelError;
 

--- a/libkern/Cargo.toml
+++ b/libkern/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kfs-libkern"
+version = "0.1.0"
+authors = ["roblabla <unfiltered@roblab.la>"]
+edition = "2018"
+
+[dependencies]
+kfs-libutils = { path = "../libutils" }
+bitflags = "1.0"
+
+[dependencies.lazy_static]
+features = ["spin_no_std"]
+version = "1.0.0"

--- a/libkern/src/lib.rs
+++ b/libkern/src/lib.rs
@@ -1,0 +1,221 @@
+//! Types shared by user and kernel
+
+#![no_std]
+
+#[macro_use]
+extern crate kfs_libutils;
+#[macro_use]
+extern crate bitflags;
+#[macro_use]
+extern crate lazy_static;
+
+enum_with_val! {
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    pub struct MemoryType(u32) {
+        Unmapped = 0,
+        Io = 0x00002001,
+        Normal = 0x00042002,
+        CodeStatic = 0x00DC7E03,
+        // 1.0.0-3.1.0 0x01FEBD04
+        // 4.0.0+
+        CodeMutable = 0x03FEBD04,
+        // 1.0.0-3.1.0 0x017EBD05
+        Heap = 0x037EBD05,
+        SharedMemory = 0x00402006,
+        Alias = 0x00482907,
+        ModuleCodeStatic = 0x00DD7E08,
+        // 1.0.0-3.1.0: 0x01FFBD09
+        ModuleCodeMutable = 0x03FFBD09,
+        IpcBuffer0 = 0x005C3C0A,
+        Stack = 0x005C3C0B,
+        ThreadLocal = 0x0040200C,
+        TransferMemoryIsolated = 0x015C3C0D,
+        TransferMemory = 0x005C380E,
+        ProcessMemory = 0x0040380F,
+        Reserved = 0x00000010,
+        IpcBuffer1 = 0x005C3811,
+        IpcBuffer3 = 0x004C2812,
+        KernelStack = 0x00002013,
+        CodeReadOnly = 0x00402214,
+        CodeWritable = 0x00402015,
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    pub struct MemoryAttributes : u32 {
+        const BORROWED = 1 << 0;
+        const IPC_MAPPED = 1 << 0;
+        const DEVICE_MAPPED = 1 << 2;
+        const UNCACHED = 1 << 3;
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    pub struct MemoryPermissions : u32 {
+        const READABLE = 1 << 0;
+        const WRITABLE = 1 << 1;
+        const EXECUTABLE = 1 << 2;
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct MemoryInfo {
+    pub baseaddr: usize,
+    pub size: usize,
+    pub memtype: MemoryType,
+    pub memattr: MemoryAttributes,
+    pub perms: MemoryPermissions,
+    pub ipc_ref_count: u32,
+    pub device_ref_count: u32,
+}
+
+macro_rules! syscalls {
+    (
+        static $byname:ident;
+        mod $byid:ident;
+        maxid = $maxid:expr;
+        $($name:ident = $id:expr),* $(,)*
+    ) => {
+        pub mod $byid {
+            $(
+                #[allow(non_upper_case_globals)]
+                pub const $name: usize = $id;
+            )*
+        }
+        lazy_static! {
+            pub static ref $byname: [&'static str; $maxid] = {
+                let mut arr = ["Unknown"; $maxid];
+                $(arr[$id] = stringify!($name);)*
+                arr
+            };
+        }
+    }
+}
+
+syscalls! {
+    static SYSCALL_NAMES;
+    mod nr;
+    maxid = 0x82;
+    SetHeapSize = 0x01,
+    SetMemoryPermission = 0x02,
+    SetMemoryAttribute = 0x03,
+    MapMemory = 0x04,
+    UnmapMemory = 0x05,
+    QueryMemory = 0x06,
+    ExitProcess = 0x07,
+    CreateThread = 0x08,
+    StartThread = 0x09,
+    ExitThread = 0x0A,
+    SleepThread = 0x0B,
+    GetThreadPriority = 0x0C,
+    SetThreadPriority = 0x0D,
+    GetThreadCoreMask = 0x0E,
+    SetThreadCoreMask = 0x0F,
+    GetCurrentProcessorNumber = 0x10,
+    SignalEvent = 0x11,
+    ClearEvent = 0x12,
+    MapSharedMemory = 0x13,
+    UnmapSharedMemory = 0x14,
+    CreateTransferMemory = 0x15,
+    CloseHandle = 0x16,
+    ResetSignal = 0x17,
+    WaitSynchronization = 0x18,
+    CancelSynchronization = 0x19,
+    ArbitrateLock = 0x1A,
+    ArbitrateUnlock = 0x1B,
+    WaitProcessWideKeyAtomic = 0x1C,
+    SignalProcessWideKey = 0x1D,
+    GetSystemTick = 0x1E,
+    ConnectToNamedPort = 0x1F,
+    SendSyncRequestLight = 0x20,
+    SendSyncRequest = 0x21,
+    SendSyncRequestWithUserBuffer = 0x22,
+    SendAsyncRequestWithUserBuffer = 0x23,
+    GetProcessId = 0x24,
+    GetThreadId = 0x25,
+    Break = 0x26,
+    OutputDebugString = 0x27,
+    ReturnFromException = 0x28,
+    GetInfo = 0x29,
+    FlushEntireDataCache = 0x2A,
+    FlushDataCache = 0x2B,
+    MapPhysicalMemory = 0x2C,
+    UnmapPhysicalMemory = 0x2D,
+    GetFutureThreadInfo = 0x2E,
+    GetLastThreadInfo = 0x2F,
+    GetResourceLimitLimitValue = 0x30,
+    GetResourceLimitCurrentValue = 0x31,
+    SetThreadActivity = 0x32,
+    GetThreadContext3 = 0x33,
+    WaitForAddress = 0x34,
+    SignalToAddress = 0x35,
+    DumpInfo = 0x3C,
+    DumpInfoNew = 0x3D,
+    CreateSession = 0x40,
+    AcceptSession = 0x41,
+    ReplyAndReceiveLight = 0x42,
+    ReplyAndReceive = 0x43,
+    ReplyAndReceiveWithUserBuffer = 0x44,
+    CreateEvent = 0x45,
+    MapPhysicalMemoryUnsafe = 0x48,
+    UnmapPhysicalMemoryUnsafe = 0x49,
+    SetUnsafeLimit = 0x4A,
+    CreateCodeMemory = 0x4B,
+    ControlCodeMemory = 0x4C,
+    SleepSystem = 0x4D,
+    ReadWriteRegister = 0x4E,
+    SetProcessActivity = 0x4F,
+    CreateSharedMemory = 0x50,
+    MapTransferMemory = 0x51,
+    UnmapTransferMemory = 0x52,
+    CreateInterruptEvent = 0x53,
+    QueryPhysicalAddress = 0x54,
+    QueryIoMapping = 0x55,
+    CreateDeviceAddressSpace = 0x56,
+    AttachDeviceAddressSpace = 0x57,
+    DetachDeviceAddressSpace = 0x58,
+    MapDeviceAddressSpaceByForce = 0x59,
+    MapDeviceAddressSpaceAligned = 0x5A,
+    MapDeviceAddressSpace = 0x5B,
+    UnmapDeviceAddressSpace = 0x5C,
+    InvalidateProcessDataCache = 0x5D,
+    StoreProcessDataCache = 0x5E,
+    FlushProcessDataCache = 0x5F,
+    DebugActiveProcess = 0x60,
+    BreakDebugProcess = 0x61,
+    TerminateDebugProcess = 0x62,
+    GetDebugEvent = 0x63,
+    ContinueDebugEvent = 0x64,
+    GetProcessList = 0x65,
+    GetThreadList = 0x66,
+    GetDebugThreadContext = 0x67,
+    SetDebugThreadContext = 0x68,
+    QueryDebugProcessMemory = 0x69,
+    ReadDebugProcessMemory = 0x6A,
+    WriteDebugProcessMemory = 0x6B,
+    SetHardwareBreakPoint = 0x6C,
+    GetDebugThreadParam = 0x6D,
+    GetSystemInfo = 0x6F,
+    CreatePort = 0x70,
+    ManageNamedPort = 0x71,
+    ConnectToPort = 0x72,
+    SetProcessMemoryPermission = 0x73,
+    MapProcessMemory = 0x74,
+    UnmapProcessMemory = 0x75,
+    QueryProcessMemory = 0x76,
+    MapProcessCodeMemory = 0x77,
+    UnmapProcessCodeMemory = 0x78,
+    CreateProcess = 0x79,
+    StartProcess = 0x7A,
+    TerminateProcess = 0x7B,
+    GetProcessInfo = 0x7C,
+    CreateResourceLimit = 0x7D,
+    SetResourceLimitLimitValue = 0x7E,
+    CallSecureMonitor = 0x7F,
+
+    MapFramebuffer = 0x80,
+    StartProcessEntrypoint = 0x81,
+}

--- a/libuser/Cargo.toml
+++ b/libuser/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libuser"
+name = "kfs-libuser"
 version = "0.1.0"
 authors = ["roblabla <unfiltered@roblab.la>", "orycterope <tvermeilh@gmail.com>"]
 

--- a/libuser/Cargo.toml
+++ b/libuser/Cargo.toml
@@ -8,7 +8,7 @@ linked_list_allocator = "0.6.2"
 bitfield = "0.13"
 bit_field = "0.9"
 spin = "0.4"
-kfs-utils = { path = "../libutils" }
+kfs-libutils = { path = "../libutils" }
 
 [dependencies.byteorder]
 default-features = false

--- a/libuser/Cargo.toml
+++ b/libuser/Cargo.toml
@@ -9,6 +9,7 @@ bitfield = "0.13"
 bit_field = "0.9"
 spin = "0.4"
 kfs-libutils = { path = "../libutils" }
+kfs-libkern = { path = "../libkern" }
 
 [dependencies.byteorder]
 default-features = false

--- a/libuser/src/lib.rs
+++ b/libuser/src/lib.rs
@@ -15,7 +15,7 @@ extern crate bitfield;
 extern crate bit_field;
 extern crate spin;
 #[macro_use]
-extern crate kfs_utils;
+extern crate kfs_libutils;
 
 pub mod syscalls;
 pub mod io;
@@ -23,7 +23,7 @@ pub mod types;
 pub mod ipc;
 pub mod sm;
 
-use kfs_utils as utils;
+use kfs_libutils as utils;
 use linked_list_allocator::LockedHeap;
 
 #[global_allocator]

--- a/libuser/src/lib.rs
+++ b/libuser/src/lib.rs
@@ -16,6 +16,7 @@ extern crate bit_field;
 extern crate spin;
 #[macro_use]
 extern crate kfs_libutils;
+extern crate kfs_libkern;
 
 pub mod syscalls;
 pub mod io;

--- a/libutils/Cargo.toml
+++ b/libutils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "kfs-utils"
+name = "kfs-libutils"
 version = "0.1.0"
 authors = ["roblabla <unfiltered@roblab.la>", "orycterope <tvermeilh@gmail.com>"]
 

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -9,7 +9,7 @@ font-rs = { git = "https://github.com/orycterope/font-rs" }
 spin = "0.4"
 hashmap_core = "0.1.9"
 log = "0.4.2"
-libuser = { path = "../libuser" }
+kfs-libuser = { path = "../libuser" }
 
 [dependencies.byteorder]
 default-features = false

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
-extern crate libuser;
+extern crate kfs_libuser as libuser;
 extern crate byteorder;
 
 mod vbe;

--- a/sm/Cargo.toml
+++ b/sm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["roblabla <unfiltered@roblab.la>", "orycterope <tvermeilh@gmail.com>"]
 
 [dependencies]
-libuser = { path = "../libuser" }
+kfs-libuser = { path = "../libuser" }
 spin = "0.4"
 hashmap_core = "0.1.9"
 

--- a/sm/src/main.rs
+++ b/sm/src/main.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 #[macro_use]
-extern crate libuser;
+extern crate kfs_libuser as libuser;
 #[macro_use]
 extern crate alloc;
 extern crate spin;

--- a/vi/Cargo.toml
+++ b/vi/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["roblabla <unfiltered@roblab.la>"]
 
 [dependencies]
-libuser = { path = "../libuser" }
+kfs-libuser = { path = "../libuser" }
 spin = "0.4"
 hashmap_core = "0.1.9"
 

--- a/vi/src/main.rs
+++ b/vi/src/main.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 #[macro_use]
-extern crate libuser;
+extern crate kfs_libuser as libuser;
 #[macro_use]
 extern crate alloc;
 extern crate spin;


### PR DESCRIPTION
libkern will contain all the types shared between libuser and the kernel. It's similar to linux's uapi.

This also renames all the libraries to have a common prefix: `kfs-lib`.