### PR TITLE
Warn on unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,6 @@ dependencies = [
 name = "kfs-kernel"
 version = "0.1.0"
 dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -32,10 +32,6 @@ bitfield = "0.13"
 default-features = false
 version = "0.6.2"
 
-[dependencies.arrayvec]
-default-features = false
-version = "0.4.7"
-
 [dependencies.byteorder]
 default-features = false
 version = "1.2.1"

--- a/kernel/src/devices/pic.rs
+++ b/kernel/src/devices/pic.rs
@@ -143,7 +143,7 @@ impl InternalPic {
     /// Mask the given IRQ
     pub fn mask(&mut self, irq: u8) {
         let mut data = self.port_data.read();
-        data |= (1 << irq);
+        data |= 1 << irq;
         self.port_data.write(data);
     }
 }

--- a/kernel/src/devices/pit.rs
+++ b/kernel/src/devices/pit.rs
@@ -113,7 +113,7 @@ struct PITPorts {
 impl PITPorts {
     /// Writes a reload value in lobyte/hibyte access mode
     fn write_reload_value(&mut self, channel_selector: ChannelSelector, value: u16) {
-        let mut port = match channel_selector {
+        let port = match channel_selector {
             ChannelSelector::Channel0 => &mut self.port_chan_0,
             ChannelSelector::Channel2 => &mut self.port_chan_2
         };

--- a/kernel/src/devices/rs232.rs
+++ b/kernel/src/devices/rs232.rs
@@ -90,6 +90,7 @@ pub struct SerialInternal<T> {
 impl <T> SerialInternal<T> {
     /// Creates the serial for i386
     #[cfg(target_arch="x86")]
+    #[allow(unused)]
     pub fn new(com_port: ComPort) -> SerialInternal<Pio<u8>> {
         let mut data_port       = Pio::<u8>::new(com_port.0 + 0);
         let mut interrupt_port  = Pio::<u8>::new(com_port.0 + 1);

--- a/kernel/src/elf_loader.rs
+++ b/kernel/src/elf_loader.rs
@@ -14,12 +14,10 @@
 //! does not do any dynamic loading or provide ASLR (though that is up for change)
 
 use multiboot2::ModuleTag;
-use core::fmt::Write;
 use core::slice;
 use xmas_elf::ElfFile;
 use xmas_elf::program::{ProgramHeader, Type::Load, SegmentData};
 use mem::{VirtualAddress, PhysicalAddress};
-use paging::lands::{KernelLand, UserLand};
 use paging::{PAGE_SIZE, MappingFlags, process_memory::ProcessMemory, kernel_memory::get_kernel_memory};
 use frame_allocator::PhysicalMemRegion;
 use utils::{self, align_up};

--- a/kernel/src/event.rs
+++ b/kernel/src/event.rs
@@ -14,8 +14,8 @@ use core::fmt::Debug;
 use alloc::sync::Arc;
 use sync::SpinLockIRQ;
 use alloc::vec::Vec;
-use error::{KernelError, UserspaceError};
-use process::{ThreadStruct, ThreadState};
+use error::UserspaceError;
+use process::ThreadStruct;
 use scheduler;
 
 // TODO: maybe we should use the libcore's task:: stuff...

--- a/kernel/src/frame_allocator/i386.rs
+++ b/kernel/src/frame_allocator/i386.rs
@@ -145,7 +145,6 @@ impl FrameAllocatorTrait for FrameAllocator {
                     FRAME_OCCUPIED => {
                         // hole wasn't big enough, jump to its end
                         start_index += temp_len + 1;
-                        temp_len = 0;
                         break;
                     }
                     FRAME_FREE => {

--- a/kernel/src/frame_allocator/i386.rs
+++ b/kernel/src/frame_allocator/i386.rs
@@ -14,16 +14,15 @@
 //!
 //! We do not distinguish between reserved and occupied frames.
 
-use super::{PhysicalMemRegion, PhysicalMemRegionIter,
-            FrameAllocatorTrait, FrameAllocatorTraitPrivate};
+use super::{PhysicalMemRegion, FrameAllocatorTrait, FrameAllocatorTraitPrivate};
 
 use multiboot2::BootInformation;
 use sync::SpinLock;
 use alloc::vec::Vec;
 use bit_field::BitArray;
-use utils::{bit_array_first_one, BitArrayExt};
+use utils::BitArrayExt;
 use mem::PhysicalAddress;
-use mem::{round_to_page, round_to_page_upper, count_pages};
+use mem::{round_to_page, round_to_page_upper};
 use paging::kernel_memory::get_kernel_memory;
 use error::KernelError;
 use failure::Backtrace;

--- a/kernel/src/frame_allocator/mod.rs
+++ b/kernel/src/frame_allocator/mod.rs
@@ -4,11 +4,11 @@
 
 use alloc::vec::Vec;
 use mem::PhysicalAddress;
-use utils::{align_down, align_up, div_ceil, check_aligned};
+use utils::{align_down, div_ceil, check_aligned};
 use utils::Splittable;
-use core::ops::{Index, Range};
+use core::ops::Range;
 use core::iter::StepBy;
-use core::fmt::{Formatter, Error, Display, Debug};
+use core::fmt::{Formatter, Error, Debug};
 use core::marker::PhantomData;
 use error::KernelError;
 

--- a/kernel/src/gdt/mod.rs
+++ b/kernel/src/gdt/mod.rs
@@ -34,7 +34,7 @@ pub fn init_gdt() {
 
     let ldt = GLOBAL_LDT.call_once(|| DescriptorTable::new());
 
-    let gdt = GDT.call_once(|| {
+    GDT.call_once(|| {
         let mut gdt = DescriptorTable::new();
         // Push the null descriptor
         gdt.push(DescriptorTableEntry::null_descriptor());
@@ -196,7 +196,7 @@ impl DescriptorTable {
     pub fn set_from_loaded(&mut self) {
         use core::slice;
 
-        let mut loaded_ptr = sgdt();
+        let loaded_ptr = sgdt();
         let loaded_table = unsafe {
             slice::from_raw_parts(loaded_ptr.base as *mut DescriptorTableEntry, loaded_ptr.limit as usize / size_of::<DescriptorTableEntry>())
         };

--- a/kernel/src/gdt/mod.rs
+++ b/kernel/src/gdt/mod.rs
@@ -6,7 +6,6 @@
 #![allow(dead_code)]
 
 use sync::{SpinLock, Once};
-use arrayvec::ArrayVec;
 use bit_field::BitField;
 use core::mem::{self, size_of};
 use core::ops::{Deref, DerefMut};
@@ -19,7 +18,6 @@ use i386::instructions::tables::{lgdt, sgdt, DescriptorTablePointer};
 use i386::instructions::segmentation::*;
 
 use paging::PAGE_SIZE;
-use paging::lands::KernelLand;
 use paging::{MappingFlags, kernel_memory::get_kernel_memory};
 use frame_allocator::{FrameAllocator, FrameAllocatorTrait};
 use mem::VirtualAddress;

--- a/kernel/src/heap_allocator.rs
+++ b/kernel/src/heap_allocator.rs
@@ -7,7 +7,6 @@ use sync::{SpinLock, Once};
 use core::ops::Deref;
 use core::ptr::NonNull;
 use linked_list_allocator::{Heap, align_up};
-use paging::lands::KernelLand;
 use paging::{PAGE_SIZE, MappingFlags, kernel_memory::get_kernel_memory};
 use frame_allocator::{FrameAllocator, FrameAllocatorTrait};
 use mem::VirtualAddress;

--- a/kernel/src/i386/mod.rs
+++ b/kernel/src/i386/mod.rs
@@ -4,7 +4,6 @@
 #![cfg(target_arch = "x86")]
 #![allow(dead_code)]
 
-use core::fmt;
 use alloc::boxed::Box;
 use core::ops::{Deref, DerefMut};
 
@@ -328,9 +327,6 @@ impl Default for TssStruct {
 }
 
 const_assert_eq!(tss_struct_size; ::core::mem::size_of::<TssStruct>(), 0x68);
-
-use i386::structures::gdt::SegmentSelector;
-use mem::PhysicalAddress;
 
 impl TssStruct {
     /// Creates a new TssStruct.

--- a/kernel/src/i386/process_switch.rs
+++ b/kernel/src/i386/process_switch.rs
@@ -2,10 +2,8 @@
 //!
 //! This modules describe low-level functions and structures needed to perform a process switch
 
-use process::{ProcessStruct, ThreadStruct, ThreadState};
-use paging::process_memory::ProcessMemory;
+use process::ThreadStruct;
 use gdt;
-use sync::{SpinLockIRQ, RwLock};
 use alloc::sync::Arc;
 use core::mem::size_of;
 use i386::TssStruct;

--- a/kernel/src/i386/stack.rs
+++ b/kernel/src/i386/stack.rs
@@ -123,9 +123,9 @@ impl KernelStack {
 
     /// Dumps the stack, displaying it in a frame-by-frame format
     pub fn dump_current_stack() {
-        let mut ebp;
-        let mut esp;
-        let mut eip;
+        let ebp;
+        let esp;
+        let eip;
         unsafe {
             asm!("
                 mov $0, ebp
@@ -147,7 +147,7 @@ impl KernelStack {
     /// This function is "relatively" safe. It checks whether the stack is properly mapped
     /// before attempting to access it. It does create a &[u8] from a technically "shared"
     /// resource. However, the compiler shouldn't know about this, so UB shouldn't be met.
-    pub fn dump_stack<'a>(mut esp: usize, ebp: usize, eip: usize, elf: Option<(&ElfFile<'a>, &'a [Entry32])>) {
+    pub fn dump_stack<'a>(esp: usize, ebp: usize, eip: usize, elf: Option<(&ElfFile<'a>, &'a [Entry32])>) {
         let mut kmemory = get_kernel_memory();
         let process = scheduler::get_current_process();
         let pmemory = process.pmemory.lock();
@@ -211,6 +211,7 @@ impl Drop for KernelStack {
 /// * any ebp/esp falling outside of the stack
 ///
 /// The data of every stack frame will be hexdumped
+#[allow(unused_must_use)]
 pub fn dump_stack<'a>(stack: &[u8], orig_address: usize, mut esp: usize, mut ebp: usize, mut eip: usize, elf: Option<(&ElfFile<'a>, &'a [Entry32])>) {
     use devices::rs232::SerialLogger;
     use core::fmt::Write;

--- a/kernel/src/i386/structures/idt.rs
+++ b/kernel/src/i386/structures/idt.rs
@@ -16,8 +16,7 @@ use core::ops::{Index, IndexMut};
 use bit_field::BitField;
 use i386::{AlignedTssStruct, TssStruct, PrivilegeLevel};
 use mem::VirtualAddress;
-use paging::{PAGE_SIZE, lands::KernelLand, kernel_memory::get_kernel_memory};
-use i386::structures::gdt::SegmentSelector;
+use paging::{PAGE_SIZE, kernel_memory::get_kernel_memory};
 use alloc::boxed::Box;
 use gdt;
 
@@ -520,7 +519,6 @@ impl<F> IdtEntry<F> {
     }
 
     pub fn set_handler_task_gate_addr(&mut self, addr: u32) {
-        use i386::instructions::segmentation;
 
         self.pointer_low = 0;
         self.pointer_high = 0;

--- a/kernel/src/interrupts/irq.rs
+++ b/kernel/src/interrupts/irq.rs
@@ -1,7 +1,4 @@
-use i386::pio::Pio;
-use io::Io;
 use i386::structures::idt::ExceptionStackFrame;
-use core::fmt::Write;
 use devices::pic;
 
 fn acknowledge_irq(irq: u8) {

--- a/kernel/src/interrupts/irq.rs
+++ b/kernel/src/interrupts/irq.rs
@@ -5,11 +5,12 @@ fn acknowledge_irq(irq: u8) {
     pic::get().acknowledge(irq)
 }
 
-extern "x86-interrupt" fn timer_handler(stack_frame: &mut ExceptionStackFrame) {
+extern "x86-interrupt" fn timer_handler(_stack_frame: &mut ExceptionStackFrame) {
     // TODO: Reroute this into a generic interrupt system?
     acknowledge_irq(0);
 }
 
+#[allow(unused)]
 macro_rules! irq_handler_none {
     ($irq:expr, $name:ident) => {{
         extern "x86-interrupt" fn $name(stack_frame: &mut ExceptionStackFrame) {
@@ -22,7 +23,7 @@ macro_rules! irq_handler_none {
 
 macro_rules! irq_handler {
     ($irq:expr, $name:ident) => {{
-        extern "x86-interrupt" fn $name(stack_frame: &mut ExceptionStackFrame) {
+        extern "x86-interrupt" fn $name(_stack_frame: &mut ExceptionStackFrame) {
             acknowledge_irq($irq);
             ::event::dispatch_event($irq);
         }

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -30,7 +30,7 @@ pub fn check_thread_killed() {
     if scheduler::get_current_thread().state.load(Ordering::SeqCst) == ThreadState::Killed {
         let lock = SpinLockIRQ::new(());
         loop { // in case of spurious wakeups
-            scheduler::unschedule(&lock, lock.lock());
+            let _ = scheduler::unschedule(&lock, lock.lock());
         }
     }
 }
@@ -77,7 +77,7 @@ extern "x86-interrupt" fn non_maskable_interrupt_handler(stack_frame: &mut Excep
     panic_on_exception(format_args!("An unexpected non-maskable (but still kinda maskable) interrupt occured"), stack_frame);
 }
 
-extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut ExceptionStackFrame) {
+extern "x86-interrupt" fn breakpoint_handler(_stack_frame: &mut ExceptionStackFrame) {
     // don't do anything
 }
 

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -49,8 +49,9 @@ fn panic_on_exception(exception_string: Arguments, exception_stack_frame: &Excep
 }
 
 extern "x86-interrupt" fn divide_by_zero_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Divide Error Exception"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Divide Error Exception"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Divide Error Exception in {:#?}", thread);
@@ -60,8 +61,9 @@ extern "x86-interrupt" fn divide_by_zero_handler(stack_frame: &mut ExceptionStac
 }
 
 extern "x86-interrupt" fn debug_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Debug Exception"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Debug Exception"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Debug Exception in {:#?}", thread);
@@ -80,8 +82,9 @@ extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut ExceptionStackFra
 }
 
 extern "x86-interrupt" fn overflow_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Overflow Exception"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Overflow Exception"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Overflow Exception in {:#?}", thread);
@@ -91,8 +94,9 @@ extern "x86-interrupt" fn overflow_handler(stack_frame: &mut ExceptionStackFrame
 }
 
 extern "x86-interrupt" fn bound_range_exceeded_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("BOUND Range Exceeded Exception"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("BOUND Range Exceeded Exception"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("BOUND Range Exceeded Exception in {:#?}", thread);
@@ -102,8 +106,9 @@ extern "x86-interrupt" fn bound_range_exceeded_handler(stack_frame: &mut Excepti
 }
 
 extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Invalid opcode Exception"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Invalid opcode Exception"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Invalid opcode Exception in {:#?}", thread);
@@ -113,8 +118,9 @@ extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: &mut ExceptionStac
 }
 
 extern "x86-interrupt" fn device_not_available_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Device Not Available Exception"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Device Not Available Exception"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Device Not Available Exception in {:#?}", thread);
@@ -149,8 +155,9 @@ extern "x86-interrupt" fn invalid_tss_handler(stack_frame: &mut ExceptionStackFr
 }
 
 extern "x86-interrupt" fn segment_not_present_handler(stack_frame: &mut ExceptionStackFrame, errcode: u32) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Segment Not Present: error code: {:?}", errcode), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Segment Not Present: error code: {:?}", errcode), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Segment Not Present in {:#?}", thread);
@@ -160,8 +167,9 @@ extern "x86-interrupt" fn segment_not_present_handler(stack_frame: &mut Exceptio
 }
 
 extern "x86-interrupt" fn stack_segment_fault_handler(stack_frame: &mut ExceptionStackFrame, errcode: u32) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Stack Fault Exception: error code: {:?}", errcode), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Stack Fault Exception: error code: {:?}", errcode), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Exception : Stack Fault Exception in {:#?}", thread);
@@ -171,8 +179,9 @@ extern "x86-interrupt" fn stack_segment_fault_handler(stack_frame: &mut Exceptio
 }
 
 extern "x86-interrupt" fn general_protection_fault_handler(stack_frame: &mut ExceptionStackFrame, errcode: u32) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("General Protection Fault Exception: error code: {:?}", errcode), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("General Protection Fault Exception: error code: {:?}", errcode), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Exception : General Protection Fault Exception in {:#?}", thread);
@@ -184,8 +193,9 @@ extern "x86-interrupt" fn general_protection_fault_handler(stack_frame: &mut Exc
 extern "x86-interrupt" fn page_fault_handler(stack_frame: &mut ExceptionStackFrame, errcode: PageFaultErrorCode) {
     let cause_address = ::paging::read_cr2();
 
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Page Fault accessing {:?}, error: {:?}", cause_address, errcode), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Page Fault accessing {:?}, error: {:?}", cause_address, errcode), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Exception : Page Fault accessing {:?}, error: {:?} in {:#?}", cause_address, errcode, thread);
@@ -195,8 +205,9 @@ extern "x86-interrupt" fn page_fault_handler(stack_frame: &mut ExceptionStackFra
 }
 
 extern "x86-interrupt" fn x87_floating_point_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("x87 FPU floating-point error"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("x87 FPU floating-point error"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("x87 FPU floating-point error in {:#?}", thread);
@@ -206,8 +217,9 @@ extern "x86-interrupt" fn x87_floating_point_handler(stack_frame: &mut Exception
 }
 
 extern "x86-interrupt" fn alignment_check_handler(stack_frame: &mut ExceptionStackFrame, errcode: u32) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Alignment Check Exception: error code: {:?}", errcode), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Alignment Check Exception: error code: {:?}", errcode), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Alignment Check Exception in {:#?}", thread);
@@ -222,8 +234,9 @@ extern "x86-interrupt" fn machine_check_handler(stack_frame: &mut ExceptionStack
 }
 
 extern "x86-interrupt" fn simd_floating_point_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("SIMD Floating-Point Exception"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("SIMD Floating-Point Exception"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("SIMD Floating-Point Exception in {:#?}", thread);
@@ -233,8 +246,9 @@ extern "x86-interrupt" fn simd_floating_point_handler(stack_frame: &mut Exceptio
 }
 
 extern "x86-interrupt" fn virtualization_handler(stack_frame: &mut ExceptionStackFrame) {
-    #[cfg(feature = "panic-on-exception")]
-    { panic_on_exception(format_args!("Virtualization Exception"), stack_frame); }
+    if cfg!(feature = "panic-on-exception") {
+        panic_on_exception(format_args!("Virtualization Exception"), stack_frame);
+    }
 
     let thread = get_current_thread();
     warn!("Virtualization Exception in {:#?}", thread);

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -8,26 +8,17 @@
 
 use i386::structures::idt::{ExceptionStackFrame, PageFaultErrorCode, Idt};
 use i386::instructions::interrupts::sti;
-use i386::pio::Pio;
-use io::Io;
-use mem::{VirtualAddress, PhysicalAddress};
-use paging::lands::KernelLand;
-use paging::{MappingFlags, kernel_memory::get_kernel_memory};
-use i386::{stack, TssStruct, PrivilegeLevel};
-use i386;
+use mem::VirtualAddress;
+use paging::kernel_memory::get_kernel_memory;
+use i386::{TssStruct, PrivilegeLevel};
 use gdt;
-use xmas_elf::ElfFile;
-use xmas_elf::sections::SectionData;
 use scheduler::get_current_thread;
 use process::{ProcessStruct, ThreadState};
 use sync::SpinLockIRQ;
 use core::sync::atomic::Ordering;
 
-use core::fmt::{Write, Arguments};
-use core::slice;
+use core::fmt::Arguments;
 use sync::SpinLock;
-use sync;
-use utils;
 use devices::pic;
 use scheduler;
 

--- a/kernel/src/interrupts/syscalls.rs
+++ b/kernel/src/interrupts/syscalls.rs
@@ -49,7 +49,7 @@ fn map_framebuffer() -> Result<(usize, usize, usize, usize), UserspaceError> {
     Ok((addr, width, height, bpp))
 }
 
-fn create_interrupt_event(irq_num: usize, flag: u32) -> Result<usize, UserspaceError> {
+fn create_interrupt_event(irq_num: usize, _flag: u32) -> Result<usize, UserspaceError> {
     // TODO: Flags?
     let curproc = scheduler::get_current_process();
     let hnd = curproc.phandles.lock().add_handle(Arc::new(Handle::ReadableEvent(Box::new(event::wait_event(irq_num)))));

--- a/kernel/src/interrupts/syscalls.rs
+++ b/kernel/src/interrupts/syscalls.rs
@@ -2,24 +2,19 @@
 
 use i386;
 use mem::{VirtualAddress, PhysicalAddress};
-use mem::{FatPtr, UserSpacePtr, UserSpacePtrMut};
-use paging::{PAGE_SIZE, MappingFlags};
-use paging::lands::{UserLand, KernelLand};
+use mem::{UserSpacePtr, UserSpacePtrMut};
+use paging::MappingFlags;
 use frame_allocator::PhysicalMemRegion;
-use process::{Handle, ThreadStruct, ThreadState, ProcessStruct};
+use process::{Handle, ThreadStruct, ProcessStruct};
 use event::{self, Waitable};
 use scheduler::{self, get_current_thread, get_current_process};
-use utils;
 use devices::pit;
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use core::mem;
-use core::sync::atomic::Ordering;
-use sync::SpinLockIRQ;
 use ipc;
-use error::{KernelError, UserspaceError};
+use error::UserspaceError;
 use kfs_libkern::{nr, SYSCALL_NAMES};
 use super::check_thread_killed;
 
@@ -290,7 +285,6 @@ pub struct Registers {
 
 // TODO: Get a 6th argument in by putting the syscall_nr in the interrupt struct.
 pub extern fn syscall_handler_inner(registers: &mut Registers) {
-    use devices::rs232::SerialLogger;
 
     let (syscall_nr, x0, x1, x2, x3, x4, x5) = (registers.eax, registers.ebx, registers.ecx, registers.edx, registers.esi, registers.edi, registers.ebp);
 

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -77,16 +77,10 @@
 //! let clientsess = ipc::connect_to_named_port(b"test\0\0\0\0\0\0\0\0\0\0\0\0")?;
 //! ```
 
-use sync::{Once, SpinLock, RwLock};
-use alloc::vec::Vec;
+use sync::RwLock;
 use alloc::string::String;
-use alloc::sync::{Arc, Weak};
-use core::sync::atomic::{AtomicUsize, Ordering};
-use scheduler;
 use error::UserspaceError;
-use event::{self, Waitable};
 use hashmap_core::HashMap;
-use process::ProcessStruct;
 
 pub mod session;
 pub mod port;

--- a/kernel/src/ipc/port.rs
+++ b/kernel/src/ipc/port.rs
@@ -1,13 +1,11 @@
 use scheduler;
 use alloc::vec::Vec;
 use alloc::sync::{Arc, Weak};
-use sync::{Once, SpinLock, RwLock};
-use error::{KernelError, UserspaceError};
+use sync::SpinLock;
+use error::UserspaceError;
 use event::{self, Waitable};
 use process::ThreadStruct;
 use core::sync::atomic::{AtomicUsize, Ordering};
-use hashmap_core::HashMap;
-use alloc::prelude::*;
 use ipc::session::{self, ClientSession, ServerSession};
 
 /// An endpoint which can be connected to.

--- a/kernel/src/ipc/port.rs
+++ b/kernel/src/ipc/port.rs
@@ -138,7 +138,7 @@ impl ClientPort {
         });
 
         let mut guard = incoming.session.lock();
-        let lock = self.0.incoming_connections.lock().push(incoming.clone());
+        self.0.incoming_connections.lock().push(incoming.clone());
 
         let session = loop {
             // If no handle to the server exist anymore, give up.

--- a/kernel/src/ipc/session.rs
+++ b/kernel/src/ipc/session.rs
@@ -1,14 +1,14 @@
 use scheduler;
 use alloc::vec::Vec;
 use alloc::sync::{Arc, Weak};
-use sync::{Once, SpinLock, RwLock};
+use sync::SpinLock;
 use error::UserspaceError;
-use event::{self, Waitable};
+use event::Waitable;
 use process::ThreadStruct;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::slice;
 use byteorder::{LE, ByteOrder};
-use paging::{self, MappingFlags, mapping::MappingType, process_memory::ProcessMemory, kernel_memory::get_kernel_memory};
+use paging::{MappingFlags, mapping::MappingType, process_memory::ProcessMemory};
 use mem::{UserSpacePtr, UserSpacePtrMut, VirtualAddress};
 use bit_field::BitField;
 

--- a/kernel/src/ipc/session.rs
+++ b/kernel/src/ipc/session.rs
@@ -141,7 +141,8 @@ struct Request {
     sender: Arc<ThreadStruct>,
     answered: Arc<SpinLock<Option<Result<(), UserspaceError>>>>,
 }
-
+// TODO finish buf_map
+#[allow(unused)]
 fn buf_map(from_buf: &[u8], to_buf: &mut [u8], curoff: &mut usize, from_mem: &mut ProcessMemory, to_mem: &mut ProcessMemory, flags: MappingFlags) -> Result<(), UserspaceError> {
     let lowersize = LE::read_u32(&from_buf[*curoff..*curoff + 4]);
     let loweraddr = LE::read_u32(&from_buf[*curoff + 4..*curoff + 8]);
@@ -294,6 +295,8 @@ impl ServerSession {
     }
 }
 
+// TODO finish pass_message
+#[allow(unused)]
 fn pass_message(from_buf: &[u8], from_proc: Arc<ThreadStruct>, to_buf: &mut [u8], to_proc: Arc<ThreadStruct>) -> Result<(), UserspaceError> {
     // TODO: Handle case where from == to. Might want to add some logic in those mutex lockings.
     // TODO: also handle case where from and to are both active.

--- a/kernel/src/log_impl/filter/mod.rs
+++ b/kernel/src/log_impl/filter/mod.rs
@@ -287,6 +287,7 @@ impl fmt::Debug for Builder {
 
 /// Parse a logging specification string (e.g: "crate1,crate2::mod3,crate3::x=error/foo")
 /// and return a vector with log directives.
+#[allow(unused_must_use)]
 fn parse_spec(spec: &str) -> (Vec<Directive>, Option<inner::Filter>) {
     let mut dirs = Vec::new();
 

--- a/kernel/src/log_impl/mod.rs
+++ b/kernel/src/log_impl/mod.rs
@@ -13,6 +13,7 @@ struct Logger {
     filter: RwLock<filter::Filter>
 }
 
+#[allow(unused_must_use)]
 impl Log for Logger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         self.filter.read().enabled(metadata)

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -18,7 +18,6 @@
 #[cfg(not(target_os = "none"))]
 use std as core;
 
-extern crate arrayvec;
 extern crate bit_field;
 #[macro_use]
 extern crate lazy_static;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -112,7 +112,7 @@ fn main() {
     let lock = sync::SpinLockIRQ::new(());
     loop {
         // TODO: Exit process.
-        scheduler::unschedule(&lock, lock.lock());
+        let _ = scheduler::unschedule(&lock, lock.lock());
     }
 }
 
@@ -146,7 +146,7 @@ pub extern "C" fn common_start(multiboot_info_addr: usize) -> ! {
 
     let log = &mut devices::rs232::SerialLogger;
     // Say hello to the world
-    writeln!(log, "\n# Welcome to {}KFS{}!\n",
+    let _ = writeln!(log, "\n# Welcome to {}KFS{}!\n",
         SerialAttributes::fg(SerialColor::LightCyan),
         SerialAttributes::default());
 
@@ -240,7 +240,7 @@ fn do_panic(msg: core::fmt::Arguments, esp: usize, ebp: usize, eip: usize) -> ! 
     let elf_and_st = get_symbols(&mapped_kernel_elf);
 
     if elf_and_st.is_none() {
-        writeln!(SerialLogger, "Panic handler: Failed to get kernel elf symbols");
+        let _ = writeln!(SerialLogger, "Panic handler: Failed to get kernel elf symbols");
     }
 
     // Then print the stack

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -9,7 +9,10 @@
 #![feature(lang_items, start, asm, global_asm, compiler_builtins_lib, naked_functions, core_intrinsics, const_fn, abi_x86_interrupt, allocator_api, alloc, box_syntax, no_more_cas, const_vec_new, range_contains)]
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", no_main)]
-#![allow(unused)]
+#![warn(unused)]
+#![allow(unused_unsafe)]
+#![allow(unreachable_code)]
+#![allow(dead_code)]
 #![recursion_limit = "1024"]
 
 #[cfg(not(target_os = "none"))]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -76,10 +76,8 @@ static ALLOCATOR: heap_allocator::Allocator = heap_allocator::Allocator::new();
 
 use i386::stack;
 use paging::{PAGE_SIZE, MappingFlags};
-use mem::{PhysicalAddress, VirtualAddress};
-use paging::lands::{KernelLand, UserLand};
-use process::{ProcessStruct, ThreadStruct, ThreadState};
-use core::sync::atomic::Ordering;
+use mem::VirtualAddress;
+use process::{ProcessStruct, ThreadStruct};
 
 unsafe fn force_double_fault() {
     loop {
@@ -141,7 +139,7 @@ pub unsafe extern fn start() -> ! {
 #[cfg(target_os = "none")]
 #[no_mangle]
 pub extern "C" fn common_start(multiboot_info_addr: usize) -> ! {
-    use devices::rs232::{SerialLogger, SerialAttributes, SerialColor};
+    use devices::rs232::{SerialAttributes, SerialColor};
 
     log_impl::early_init();
 
@@ -207,7 +205,7 @@ fn do_panic(msg: core::fmt::Arguments, esp: usize, ebp: usize, eip: usize) -> ! 
     //todo: force unlock the KernelMemory lock
     //      and also the process memory lock for userspace stack dumping (only if panic-on-excetpion ?).
 
-    use devices::rs232::{SerialLogger, SerialAttributes, SerialColor};
+    use devices::rs232::SerialLogger;
 
     let _ = writeln!(SerialLogger, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\
                                     ! Panic! at the disco\n\

--- a/kernel/src/paging/arch/i386/entry.rs
+++ b/kernel/src/paging/arch/i386/entry.rs
@@ -94,7 +94,7 @@ impl HierarchicalEntry for I386Entry {
     }
 
     /// Sets the entry
-    fn set(&mut self, frame_phys_addr: PhysicalAddress, mut flags: I386EntryFlags) {
+    fn set(&mut self, frame_phys_addr: PhysicalAddress, flags: I386EntryFlags) {
         assert_eq!(flags.contains(I386EntryFlags::PRESENT)
                 && flags.contains(I386EntryFlags::GUARD_PAGE), false,
                 "a GUARD_PAGE cannot also be PRESENT");

--- a/kernel/src/paging/arch/i386/mod.rs
+++ b/kernel/src/paging/arch/i386/mod.rs
@@ -3,8 +3,6 @@
 pub mod entry;
 pub mod table;
 
-use self::table::{ActiveHierarchy, InactiveHierarchy};
-
 use mem::{VirtualAddress, PhysicalAddress};
 
 pub const PAGE_SIZE: usize = 4096;

--- a/kernel/src/paging/arch/i386/table.rs
+++ b/kernel/src/paging/arch/i386/table.rs
@@ -36,11 +36,11 @@ impl HierarchicalTable for ActivePageTable {
 
     fn table_level() -> usize { 0 }
 
-    fn get_child_table<'a>(&'a mut self, index: usize) -> PageState<SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType>> {
+    fn get_child_table<'a>(&'a mut self, _index: usize) -> PageState<SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType>> {
         panic!("An active page table has no children");
     }
 
-    fn create_child_table<'a>(&'a mut self, index: usize) -> SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType> {
+    fn create_child_table<'a>(&'a mut self, _index: usize) -> SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType> {
         panic!("An active page table has no children");
     }
 }
@@ -124,11 +124,11 @@ impl HierarchicalTable for InactivePageTable {
 
     fn table_level() -> usize { 0 }
 
-    fn get_child_table<'a>(&'a mut self, index: usize) -> PageState<SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType>> {
+    fn get_child_table<'a>(&'a mut self, _index: usize) -> PageState<SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType>> {
         panic!("An inactive page table has no children");
     }
 
-    fn create_child_table<'a>(&'a mut self, index: usize) -> SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType> {
+    fn create_child_table<'a>(&'a mut self, _index: usize) -> SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType> {
         panic!("An inactive page table has no children");
     }
 }

--- a/kernel/src/paging/arch/i386/table.rs
+++ b/kernel/src/paging/arch/i386/table.rs
@@ -1,20 +1,16 @@
 //! i386 Page Tables hierarchy
 
-use core::ops::{Index, IndexMut, Bound, RangeBounds};
-
 use super::{PAGE_SIZE, ENTRY_COUNT};
 use super::entry::{I386Entry, I386EntryFlags};
 use super::super::super::hierarchical_table::{HierarchicalTable, SmartHierarchicalTable,
                                               TableHierarchy, InactiveHierarchyTrait,
                                               PagingCacheFlusher, PageState, NoFlush,
                                               HierarchicalEntry};
-use super::super::super::lands::{KernelLand, UserLand, RecursiveTablesLand, VirtualSpaceLand};
+use super::super::super::lands::{KernelLand, UserLand, VirtualSpaceLand};
 use super::super::super::kernel_memory::get_kernel_memory;
 use super::super::super::MappingFlags;
 use mem::{VirtualAddress, PhysicalAddress};
 use frame_allocator::{PhysicalMemRegion, FrameAllocator, FrameAllocatorTrait};
-use core::ops::{Deref, DerefMut};
-use core::marker::PhantomData;
 
 /// When paging is on, accessing this address loops back to the directory itself thanks to
 /// recursive mapping on directory's last entry

--- a/kernel/src/paging/bookkeeping.rs
+++ b/kernel/src/paging/bookkeeping.rs
@@ -162,7 +162,7 @@ impl UserspaceBookkeeping {
     /// Returns a KernelError if address falls in an available mapping.
     /// Returns a KernelError if the range spans multiple mappings.
     /// Returns a KernelError if the range falls in a Shared mapping, as it cannot be splitted.
-    pub fn remove_mapping_split(&mut self, address: VirtualAddress, length: usize) -> Result<Mapping, KernelError> {
+    pub fn remove_mapping_split(&mut self, _address: VirtualAddress, _length: usize) -> Result<Mapping, KernelError> {
         unimplemented!()
     }
 

--- a/kernel/src/paging/bookkeeping.rs
+++ b/kernel/src/paging/bookkeeping.rs
@@ -1,17 +1,13 @@
 //! Bookkeeping of mappings in UserLand
 
 use mem::VirtualAddress;
-use paging::{PAGE_SIZE, MappingFlags};
-use paging::lands::{UserLand, KernelLand, RecursiveTablesLand, VirtualSpaceLand};
-use frame_allocator::PhysicalMemRegion;
-use alloc::vec::Vec;
-use alloc::sync::Arc;
+use paging::lands::{KernelLand, RecursiveTablesLand, VirtualSpaceLand};
 use alloc::collections::BTreeMap;
-use error::{KernelError, UserspaceError};
+use error::KernelError;
 use super::error::MmError;
-use utils::{Splittable, check_aligned, check_nonzero_length};
+use utils::check_nonzero_length;
 use failure::Backtrace;
-use super::mapping::{Mapping, MappingType};
+use super::mapping::Mapping;
 
 /// A bookkeeping is just a list of Mappings
 ///

--- a/kernel/src/paging/cross_process.rs
+++ b/kernel/src/paging/cross_process.rs
@@ -33,11 +33,9 @@
 use mem::VirtualAddress;
 use super::{PAGE_SIZE, MappingFlags};
 use super::mapping::{Mapping, MappingType};
-use super::bookkeeping::UserspaceBookkeeping;
-use super::process_memory::ProcessMemory;
 use super::kernel_memory::get_kernel_memory;
 use super::error::MmError;
-use utils::{check_aligned, check_nonzero_length, add_or_error};
+use utils::{check_nonzero_length, add_or_error};
 use failure::Backtrace;
 use error::KernelError;
 

--- a/kernel/src/paging/cross_process.rs
+++ b/kernel/src/paging/cross_process.rs
@@ -44,8 +44,6 @@ pub struct CrossProcessMapping<'a> {
     kernel_address: VirtualAddress,
     len: usize,
     mapping: &'a Mapping,
-    // keep at least one private field, to forbid it from being constructed.
-    private: ()
 }
 
 impl<'a> CrossProcessMapping<'a> {
@@ -87,7 +85,6 @@ impl<'a> CrossProcessMapping<'a> {
             kernel_address: kernel_map_start + (offset % PAGE_SIZE),
             mapping,
             len,
-            private: ()
         })
     }
 

--- a/kernel/src/paging/error.rs
+++ b/kernel/src/paging/error.rs
@@ -1,6 +1,6 @@
 //! Errors specific to memory management
 
-use error::{KernelError, UserspaceError};
+use error::UserspaceError;
 use mem::VirtualAddress;
 use failure::Backtrace;
 

--- a/kernel/src/paging/hierarchical_table.rs
+++ b/kernel/src/paging/hierarchical_table.rs
@@ -1,18 +1,16 @@
 //! Arch-independent traits for architectures that implement paging as a hierarchy of page tables
 
 // what the architecture code still has define
-use super::arch::{PAGE_SIZE, ENTRY_COUNT, Entry, EntryFlags};
-use super::lands::{KernelLand, UserLand, RecursiveTablesLand, VirtualSpaceLand};
+use super::arch::{PAGE_SIZE, ENTRY_COUNT};
+use super::lands::{RecursiveTablesLand, VirtualSpaceLand};
 use super::MappingFlags;
 
 use mem::{VirtualAddress, PhysicalAddress};
-use frame_allocator::{PhysicalMemRegion, FrameAllocatorTrait};
+use frame_allocator::{PhysicalMemRegion};
 use utils::align_up_checked;
-use core::ops::IndexMut;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
-use core::iter::{Flatten, Iterator, Peekable};
-use core::slice::Iter;
+use core::iter::{Iterator, Peekable};
 
 /// A hierarchical paging is composed of entries. An entry can be in the following states:
 ///

--- a/kernel/src/paging/kernel_memory.rs
+++ b/kernel/src/paging/kernel_memory.rs
@@ -252,7 +252,7 @@ impl KernelMemory {
     pub fn unmap_no_dealloc(&mut self, address: VirtualAddress, length: usize) {
         assert!(KernelLand::contains_region(address, length));
         assert!(length % PAGE_SIZE == 0, "length must be a multiple of PAGE_SIZE");
-        self.tables.unmap(address, length, |paddr| { /* leak the frame */ });
+        self.tables.unmap(address, length, |_paddr| { /* leak the frame */ });
     }
 
     /// Marks all frames mapped in KernelLand as reserve
@@ -292,11 +292,11 @@ impl KernelMemory {
             fn update(&mut self, newstate: State) {
                 //let old_self = ::core::mem::replace(self, State::Present(VirtualAddress(0), PhysicalAddress(0)));
                 let old_self = *self;
-                let mut real_newstate = match (old_self, newstate) {
+                let real_newstate = match (old_self, newstate) {
                     // fuse guarded states
-                    (State::Guarded(addr), State::Guarded(newaddr)) => State::Guarded(addr),
+                    (State::Guarded(addr), State::Guarded(_)) => State::Guarded(addr),
                     // fuse available states
-                    (State::Available(addr), State::Available(newaddr)) => State::Available(addr),
+                    (State::Available(addr), State::Available(_)) => State::Available(addr),
                     // fuse present states only if physical frames are contiguous
                     (State::Present(addr, phys), State::Present(newaddr, newphys))
                         if newphys.addr().wrapping_sub(phys.addr()) == newaddr - addr

--- a/kernel/src/paging/mapping.rs
+++ b/kernel/src/paging/mapping.rs
@@ -159,7 +159,7 @@ impl Splittable for Mapping {
                 MappingType::Guarded => MappingType::Guarded,
                 MappingType::Regular(ref mut frames) => MappingType::Regular(frames.split_at(offset)?.unwrap()),
             //    MappingType::Stack(ref mut frames) => MappingType::Stack(frames.split_at(offset)?.unwrap()),
-                MappingType::Shared(arc) => return Err(KernelError::MmError(
+                MappingType::Shared(_) => return Err(KernelError::MmError(
                                                        MmError::SharedMapping { backtrace: Backtrace::new() })),
                 MappingType::SystemReserved => panic!("shouldn't split a SystemReserved mapping"),
             },

--- a/kernel/src/paging/mapping.rs
+++ b/kernel/src/paging/mapping.rs
@@ -2,7 +2,7 @@
 
 use mem::VirtualAddress;
 use paging::{PAGE_SIZE, MappingFlags, error::MmError};
-use error::{KernelError, ArithmeticOperation};
+use error::KernelError;
 use frame_allocator::PhysicalMemRegion;
 use alloc::{vec::Vec, sync::Arc};
 use utils::{check_aligned, check_nonzero_length, Splittable};

--- a/kernel/src/paging/process_memory.rs
+++ b/kernel/src/paging/process_memory.rs
@@ -59,11 +59,11 @@ impl HierarchicalTable for () {
         unimplemented!()
     }
 
-    fn get_child_table<'a>(&'a mut self, index: usize) -> PageState<SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType>> {
+    fn get_child_table<'a>(&'a mut self, _index: usize) -> PageState<SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType>> {
         unimplemented!()
     }
 
-    fn create_child_table<'a>(&'a mut self, index: usize) -> SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType> {
+    fn create_child_table<'a>(&'a mut self, _index: usize) -> SmartHierarchicalTable<'a, <Self as HierarchicalTable>::ChildTableType> {
         unimplemented!()
     }
 }
@@ -87,21 +87,21 @@ impl<'b> TableHierarchy for DynamicHierarchy<'b> {
         }
     }
 
-    fn guard(&mut self, address: VirtualAddress, mut length: usize) {
+    fn guard(&mut self, address: VirtualAddress, length: usize) {
         match self {
             &mut DynamicHierarchy::Active(ref mut hierarchy) => hierarchy.guard(address, length),
             &mut DynamicHierarchy::Inactive(ref mut hierarchy) => hierarchy.guard(address, length),
         }
     }
 
-    fn unmap<C>(&mut self, address: VirtualAddress, mut length: usize, callback: C) where C: FnMut(PhysicalAddress) {
+    fn unmap<C>(&mut self, address: VirtualAddress, length: usize, callback: C) where C: FnMut(PhysicalAddress) {
         match self {
             &mut DynamicHierarchy::Active(ref mut hierarchy) => hierarchy.unmap(address, length, callback),
             &mut DynamicHierarchy::Inactive(ref mut hierarchy) => hierarchy.unmap(address, length, callback),
         }
     }
 
-    fn for_every_entry<C>(&mut self, address: VirtualAddress, mut length: usize, callback: C) where C: FnMut(PageState<PhysicalAddress>, usize) {
+    fn for_every_entry<C>(&mut self, address: VirtualAddress, length: usize, callback: C) where C: FnMut(PageState<PhysicalAddress>, usize) {
         match self {
             &mut DynamicHierarchy::Active(ref mut hierarchy) => hierarchy.for_every_entry(address, length, callback),
             &mut DynamicHierarchy::Inactive(ref mut hierarchy) => hierarchy.for_every_entry(address, length, callback),

--- a/kernel/src/paging/process_memory.rs
+++ b/kernel/src/paging/process_memory.rs
@@ -17,19 +17,15 @@ pub use super::bookkeeping::QueryMemory;
 
 use super::hierarchical_table::*;
 use super::arch::{PAGE_SIZE, InactiveHierarchy, ActiveHierarchy};
-use super::lands::{UserLand, KernelLand, VirtualSpaceLand};
-use super::kernel_memory::get_kernel_memory;
+use super::lands::{UserLand, VirtualSpaceLand};
 use super::bookkeeping::UserspaceBookkeeping;
-use super::mapping::{Mapping, MappingType};
+use super::mapping::Mapping;
 use super::cross_process::CrossProcessMapping;
 use super::MappingFlags;
 use mem::{VirtualAddress, PhysicalAddress};
-use frame_allocator::{FrameAllocator, FrameAllocatorTrait, PhysicalMemRegion, mark_frame_bootstrap_allocated};
-use sync::{Mutex, MutexGuard};
-use paging::arch::EntryFlags;
+use frame_allocator::{FrameAllocator, FrameAllocatorTrait, PhysicalMemRegion};
 use paging::arch::Entry;
 use error::KernelError;
-use failure::Backtrace;
 use utils::{check_aligned, check_nonzero_length};
 use alloc::{vec::Vec, sync::Arc};
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -415,7 +415,7 @@ impl ThreadStruct {
         let empty_hwcontext = SpinLockIRQ::new(ThreadHardwareContext::new());
 
         // the state of the process, Stopped
-        let state = ThreadStateAtomic::new((ThreadState::Stopped));
+        let state = ThreadStateAtomic::new(ThreadState::Stopped);
 
         let t = Arc::new(
             ThreadStruct {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -9,7 +9,7 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 use event::Waitable;
-use sync::{RwLock, RwLockWriteGuard, SpinLockIRQ, SpinLock, Mutex, MutexGuard};
+use sync::{SpinLockIRQ, SpinLock, Mutex};
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use core::fmt::{self, Debug};
 use scheduler;

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -8,7 +8,7 @@ use process::{ProcessStruct, ThreadStruct, ThreadState};
 use i386::process_switch::process_switch;
 use sync::{Lock, SpinLockIRQ, SpinLockIRQGuard};
 use core::sync::atomic::Ordering;
-use error::{KernelError, UserspaceError};
+use error::{UserspaceError};
 
 /// An Arc to the currently running thread.
 ///

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -97,7 +97,7 @@ pub fn add_to_schedule_queue(thread: Arc<ThreadStruct>) {
         return;
     }
 
-    let mut oldstate = thread.state.compare_and_swap(ThreadState::Stopped, ThreadState::Scheduled, Ordering::SeqCst);
+    let oldstate = thread.state.compare_and_swap(ThreadState::Stopped, ThreadState::Scheduled, Ordering::SeqCst);
 
     assert!(oldstate == ThreadState::Stopped || oldstate == ThreadState::Killed,
                "Process added to schedule queue was not stopped : {:?}", oldstate);
@@ -165,7 +165,7 @@ where
 ///
 /// Panics if the schedule queue was not empty
 pub unsafe fn create_first_process() {
-    let mut queue = SCHEDULE_QUEUE.lock();
+    let queue = SCHEDULE_QUEUE.lock();
     assert!(queue.is_empty());
     let thread_0 = ThreadStruct::create_first_thread();
     unsafe {


### PR DESCRIPTION
First commit makes the kernel no longer `#![allow(unused)]`.
We still allow `dead_code`, `unused_unsafe` and `unreachable_code`.

All other commits fix all the warnings it generated. 