### PR TITLE
Fix buggy Debug implementation in SpinLockIRQ

### DIFF
--- a/kernel/src/sync.rs
+++ b/kernel/src/sync.rs
@@ -4,6 +4,7 @@ extern crate spin;
 
 pub use self::spin::{Once, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use core::fmt;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
 pub use self::spin::{Mutex as SpinLock, MutexGuard as SpinLockGuard};
@@ -73,7 +74,6 @@ pub unsafe fn permanently_disable_interrupts() {
 /// Note that it is allowed to lock/unlock the locks in a different order. It uses
 /// a global counter to disable/enable interrupts. View INTERRUPT_DISABLE_COUNTER
 /// documentation for more information.
-#[derive(Debug)]
 pub struct SpinLockIRQ<T: ?Sized> {
     internal: SpinLock<T>
 }
@@ -126,6 +126,19 @@ impl<T: ?Sized> SpinLockIRQ<T> {
 
     pub unsafe fn force_unlock(&self) {
         self.internal.force_unlock()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for SpinLockIRQ<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.try_lock() {
+            Some(d) => {
+                write!(f, "SpinLockIRQ {{ data: ")?;
+                d.fmt(f)?;
+                write!(f, "}}")
+            },
+            None => write!(f, "SpinLockIRQ {{ <locked> }}")
+        }
     }
 }
 


### PR DESCRIPTION
SpinLockIRQ should *not* derive Debug automatically, as that leads it to lock the spinlock without blocking IRQs! Instead, it should reimplement the Debug logic, calling its own try_lock function.