### PR TITLE
Better userspace error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kfs-libkern 0.1.0",
  "kfs-libutils 0.1.0",
  "linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/clock/src/vbe.rs
+++ b/clock/src/vbe.rs
@@ -11,6 +11,7 @@ use font_rs::{font, font::{Font, GlyphBitmap}};
 use spin::{Mutex, MutexGuard, Once};
 use hashmap_core::HashMap;
 use syscalls;
+use libuser::error::Error;
 
 /// A rgb color
 #[derive(Copy, Clone, Debug)]
@@ -35,7 +36,7 @@ impl Framebuffer {
     ///
     /// This function should only be called once, to ensure there is only a
     /// single mutable reference to the underlying framebuffer.
-    pub fn new() -> Result<Framebuffer, usize> {
+    pub fn new() -> Result<Framebuffer, Error> {
         let (buf, width, height, bpp) = syscalls::map_framebuffer()?;
 
         //debug!("VBE vaddr: {:#010x}", buf.as_ptr() as usize);

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -5,47 +5,7 @@ use paging::error::MmError;
 use mem::VirtualAddress;
 use core::fmt::{self, Display};
 
-#[derive(Debug, Clone, Copy)]
-pub enum UserspaceError {
-    InvalidKernelCaps = 14,
-    NotImplemented = 33,
-    InvalidSize = 101,
-    InvalidAddress = 102,
-    // SlabheapFull = 103,
-    MemoryFull = 104,
-    HandleTableFull = 105,
-    // InvalidMemState = 106,
-    InvalidMemPerms = 108,
-    // InvalidMemRange = 110,
-    // InvalidThreadPrio = 112,
-    // InvalidProcId = 113,
-    InvalidHandle = 114,
-    CopyFromUserFailed = 115,
-    InvalidCombination = 116,
-    Timeout = 117,
-    Canceled = 118,
-    ExceedingMaximum = 119,
-    // InvalidEnum = 120,
-    NoSuchEntry = 121,
-    // AlreadyRegistered = 122,
-    PortRemoteDead = 123,
-    // UnhandledInterrupt = 124,
-    ProcessAlreadyStarted = 125,
-    // ReservedValue = 126,
-    // InvalidHardwareBreakpoint = 127,
-    // FatalException = 128,
-    // LastThreadNotYours = 129,
-    // PortMaxSessions = 131,
-    // ResourceLimitExceeded = 132,
-    // CommandBufferTooSmall = 260,
-    // ProcessNotBeingDebugged = 520
-}
-
-impl UserspaceError {
-    pub fn make_ret(self) -> usize {
-        ((self as usize) << 9) | 1
-    }
-}
+pub use kfs_libkern::error::KernelError as UserspaceError;
 
 #[derive(Debug, Clone, Copy)]
 pub enum ArithmeticOperation { Add, Sub, Mul, Div, Mod, Pow }

--- a/libkern/src/error.rs
+++ b/libkern/src/error.rs
@@ -1,0 +1,81 @@
+use core::fmt;
+
+enum_with_val! {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub struct KernelError(u32) {
+        InvalidKernelCaps = 14,
+        NotImplemented = 33,
+        InvalidSize = 101,
+        InvalidAddress = 102,
+        // SlabheapFull = 103,
+        MemoryFull = 104,
+        HandleTableFull = 105,
+        // InvalidMemState = 106,
+        InvalidMemPerms = 108,
+        // InvalidMemRange = 110,
+        // InvalidThreadPrio = 112,
+        // InvalidProcId = 113,
+        InvalidHandle = 114,
+        CopyFromUserFailed = 115,
+        InvalidCombination = 116,
+        Timeout = 117,
+        Canceled = 118,
+        ExceedingMaximum = 119,
+        // InvalidEnum = 120,
+        NoSuchEntry = 121,
+        // AlreadyRegistered = 122,
+        PortRemoteDead = 123,
+        // UnhandledInterrupt = 124,
+        ProcessAlreadyStarted = 125,
+        // ReservedValue = 126,
+        // InvalidHardwareBreakpoint = 127,
+        // FatalException = 128,
+        // LastThreadNotYours = 129,
+        // PortMaxSessions = 131,
+        // ResourceLimitExceeded = 132,
+        // CommandBufferTooSmall = 260,
+        // ProcessNotBeingDebugged = 520
+    }
+}
+
+impl KernelError {
+    pub fn make_ret(self) -> usize {
+        ((self.0 as usize) << 9) | 1
+    }
+
+    pub fn from_syscall_ret(err: u32) -> KernelError {
+        KernelError(err >> 9)
+    }
+
+    pub fn from_description(err: u32) -> KernelError {
+        KernelError(err)
+    }
+
+    pub fn description(&self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for KernelError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            KernelError::InvalidKernelCaps => write!(f, "Invalid kernel capabilities. Check the format."),
+            KernelError::NotImplemented => write!(f, "Method not implemented. Notify roblabla!"),
+            KernelError::InvalidSize => write!(f, "Invalid size."),
+            KernelError::InvalidAddress => write!(f, "Invalid address."),
+            KernelError::MemoryFull => write!(f, "Memory full. Try to kill some processes and try again."),
+            KernelError::HandleTableFull => write!(f, "Handle table full. You might want to bump your handle table size in the NPDM."),
+            KernelError::InvalidMemPerms => write!(f, "Invalid memory permissions."),
+            KernelError::InvalidHandle => write!(f, "Invalid handle. Either it does not exist, or the Handle is of the wrong type."),
+            KernelError::CopyFromUserFailed => write!(f, "Copy from user failed. The pointer either does not point in userspace, or points to unmapped memory."),
+            KernelError::InvalidCombination => write!(f, "Invalid combination."),
+            KernelError::Timeout => write!(f, "Timeout exceeded."),
+            KernelError::Canceled => write!(f, "Cancelled."),
+            KernelError::ExceedingMaximum => write!(f, "Argument exceeded maximum possible value."),
+            KernelError::NoSuchEntry => write!(f, "The entry does not exist."),
+            KernelError::PortRemoteDead => write!(f, "Remote handle closed. Usually happens when an IPC got sent in the wrong format."),
+            KernelError::ProcessAlreadyStarted => write!(f, "Process already started."),
+            KernelError(err) => write!(f, "Unknown error: {}", err)
+        }
+    }
+}

--- a/libkern/src/lib.rs
+++ b/libkern/src/lib.rs
@@ -9,6 +9,8 @@ extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
 
+pub mod error;
+
 enum_with_val! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     pub struct MemoryType(u32) {

--- a/libuser/Cargo.toml
+++ b/libuser/Cargo.toml
@@ -10,6 +10,7 @@ bit_field = "0.9"
 spin = "0.4"
 kfs-libutils = { path = "../libutils" }
 kfs-libkern = { path = "../libkern" }
+failure = { version = "0.1", default-features = false, features = ["derive"] }
 
 [dependencies.byteorder]
 default-features = false

--- a/libuser/src/error.rs
+++ b/libuser/src/error.rs
@@ -23,6 +23,16 @@ impl Error {
             _ => Error::Unknown(errcode, Backtrace::new())
         }
     }
+
+    pub fn into_code(&self) -> u32 {
+        match *self {
+            Error::Kernel(err, ..) => err.description() << 9 | Module::Kernel.0,
+            Error::Sm(err, ..) => err.0 << 9 | Module::Sm.0,
+            //Error::Vi(err, ..) => err.0 << 9 | Module::Vi.0,
+            Error::Libuser(err, ..) => err.0 << 9 | Module::Libuser.0,
+            Error::Unknown(err, ..) => err,
+        }
+    }
 }
 
 impl fmt::Display for Error {

--- a/libuser/src/error.rs
+++ b/libuser/src/error.rs
@@ -1,0 +1,89 @@
+pub use kfs_libkern::error::KernelError;
+use failure::Backtrace;
+use core::fmt;
+
+#[derive(Debug, Fail)]
+pub enum Error {
+    Kernel(KernelError, Backtrace),
+    Sm(SmError, Backtrace),
+    //Vi(ViError, Backtrace),
+    Libuser(LibuserError, Backtrace),
+    Unknown(u32, Backtrace)
+}
+
+impl Error {
+    pub fn from_code(errcode: u32) -> Error {
+        let module = errcode & 0x1F;
+        let description = errcode >> 9;
+        match Module(module) {
+            Module::Kernel => Error::Kernel(KernelError::from_description(description), Backtrace::new()),
+            Module::Sm => Error::Sm(SmError(description), Backtrace::new()),
+            //Module::Vi => Error::Vi(ViError(description), Backtrace::new()),
+            Module::Libuser => Error::Libuser(LibuserError(description), Backtrace::new()),
+            _ => Error::Unknown(errcode, Backtrace::new())
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // TODO: Better Display implementation for libuser::Error
+        // BODY: Right now, the libuser::Error Display just shims back to the Debug implementation.
+        // BODY: It'd be nice if it delegated the display to the underlying Error types.
+        write!(f, "Error: {:?}", self)
+    }
+}
+
+impl From<KernelError> for Error {
+    fn from(error: KernelError) -> Self {
+        Error::Kernel(error, Backtrace::new())
+    }
+}
+
+enum_with_val! {
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    struct Module(u32) {
+        Kernel = 1,
+        Sm = 21,
+        Vi = 114,
+        Libuser = 115
+    }
+}
+
+enum_with_val! {
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    pub struct LibuserError(u32) {
+        AddressSpaceExhausted = 1,
+        InvalidMoveHandleCount = 2,
+        InvalidCopyHandleCount = 3,
+        PidMissing = 4,
+    }
+}
+
+impl From<LibuserError> for Error {
+    fn from(error: LibuserError) -> Self {
+        Error::Libuser(error, Backtrace::new())
+    }
+}
+
+
+enum_with_val! {
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    pub struct SmError(u32) {
+        OutOfProcesses = 1,
+        NotInitialized = 2,
+        MaxSessions = 3,
+        ServiceAlreadyRegistered = 4,
+        OutOfServices = 5,
+        InvalidName = 6,
+        ServiceNotRegistered = 7,
+        PermissionDenied = 8,
+        ServiceAccessControlTooBig = 9,
+    }
+}
+
+impl From<SmError> for Error {
+    fn from(error: SmError) -> Self {
+        Error::Sm(error, Backtrace::new())
+    }
+}

--- a/libuser/src/ipc/mod.rs
+++ b/libuser/src/ipc/mod.rs
@@ -5,6 +5,7 @@ use arrayvec::{ArrayVec, Array};
 use utils::{self, align_up, CursorWrite, CursorRead};
 use types::{Handle, HandleRef, Pid};
 use bit_field::BitField;
+use error::{Error, LibuserError};
 
 #[macro_use]
 pub mod macros;
@@ -179,11 +180,11 @@ where
         self
     }
 
-    pub fn error(&self) -> Result<(), usize> {
+    pub fn error(&self) -> Result<(), Error> {
         if self.cmdid_error == 0 {
             Ok(())
         } else {
-            Err(self.cmdid_error as _)
+            Err(Error::from_code(self.cmdid_error))
         }
     }
 
@@ -215,25 +216,22 @@ where
     /*fn pop_in_buffer<T>(&mut self) -> InBuffer<T> {
 }*/
 
-    pub fn pop_handle_move(&mut self) -> Result<Handle, usize> {
-        // TODO: Actual error
+    pub fn pop_handle_move(&mut self) -> Result<Handle, Error> {
         self.move_handles.pop_at(0)
             .map(Handle::new)
-            .ok_or(12)
+            .ok_or(LibuserError::InvalidMoveHandleCount.into())
     }
 
-    pub fn pop_handle_copy(&mut self) -> Result<Handle, usize> {
-        // TODO: Actual error
+    pub fn pop_handle_copy(&mut self) -> Result<Handle, Error> {
         self.copy_handles.pop_at(0)
             .map(Handle::new)
-            .ok_or(13)
+            .ok_or(LibuserError::InvalidCopyHandleCount.into())
     }
 
-    pub fn pop_pid(&mut self) -> Result<Pid, usize> {
-        // TODO: Actual error
+    pub fn pop_pid(&mut self) -> Result<Pid, Error> {
         self.pid.take()
             .map(Pid)
-            .ok_or(14)
+            .ok_or(LibuserError::PidMissing.into())
     }
 
 

--- a/libuser/src/ipc/server.rs
+++ b/libuser/src/ipc/server.rs
@@ -4,11 +4,12 @@ use core::marker::PhantomData;
 use alloc::prelude::*;
 use spin::Mutex;
 use core::ops::{Deref, DerefMut, Index};
+use error::Error;
 
 pub trait IWaitable {
     fn get_handle<'a>(&'a self) -> HandleRef<'a>;
     fn into_handle(self) -> Handle;
-    fn handle_signaled(&mut self, manager: &WaitableManager) -> Result<(), usize>;
+    fn handle_signaled(&mut self, manager: &WaitableManager) -> Result<(), Error>;
 }
 
 pub struct WaitableManager {
@@ -54,7 +55,7 @@ impl WaitableManager {
 }
 
 pub trait Object {
-    fn dispatch(&mut self, manager: &WaitableManager, cmdid: u32, buf: &mut [u8]) -> Result<(), usize>;
+    fn dispatch(&mut self, manager: &WaitableManager, cmdid: u32, buf: &mut [u8]) -> Result<(), Error>;
 }
 
 #[repr(C, align(16))]
@@ -105,7 +106,7 @@ impl<T: Object> IWaitable for SessionWrapper<T> {
         self.handle.0
     }
 
-    fn handle_signaled(&mut self, manager: &WaitableManager) -> Result<(), usize> {
+    fn handle_signaled(&mut self, manager: &WaitableManager) -> Result<(), Error> {
         self.handle.receive(&mut self.buf[..], Some(0))?;
         let (ty, cmdid) = super::find_ty_cmdid(&self.buf[..]);
         match ty {
@@ -134,7 +135,7 @@ impl<T: Object + Default + 'static> IWaitable for PortHandler<T> {
         self.handle.0
     }
 
-    fn handle_signaled(&mut self, manager: &WaitableManager) -> Result<(), usize> {
+    fn handle_signaled(&mut self, manager: &WaitableManager) -> Result<(), Error> {
         let session = Box::new(SessionWrapper {
             object: T::default(),
             handle: self.handle.accept()?,
@@ -156,7 +157,7 @@ fn encode_bytes(s: &str) -> u64 {
 }
 
 impl<T: Object + Default> PortHandler<T> {
-    pub fn new(server_name: &str) -> Result<PortHandler<T>, usize> {
+    pub fn new(server_name: &str) -> Result<PortHandler<T>, Error> {
         use sm::IUserInterface;
         let port = IUserInterface::raw_new()?.register_service(encode_bytes(server_name), false, 0)?;
         Ok(PortHandler {
@@ -165,7 +166,7 @@ impl<T: Object + Default> PortHandler<T> {
         })
     }
 
-    pub fn new_managed(server_name: &str) -> Result<PortHandler<T>, usize> {
+    pub fn new_managed(server_name: &str) -> Result<PortHandler<T>, Error> {
         let port = syscalls::manage_named_port(server_name, 0)?;
         Ok(PortHandler {
             handle: port,

--- a/libuser/src/sm.rs
+++ b/libuser/src/sm.rs
@@ -1,22 +1,22 @@
 use types::*;
+use error::{KernelError, Error};
 
 pub struct IUserInterface(ClientSession);
 
 impl IUserInterface {
-	  pub fn raw_new() -> Result<IUserInterface, usize> {
+	  pub fn raw_new() -> Result<IUserInterface, Error> {
 		    use syscalls;
 
         loop {
-            const NO_SUCH_ENTRY: usize = 121 << 9 | 1;
 		        let _ = match syscalls::connect_to_named_port("sm:\0") {
                 Ok(s) => return Ok(IUserInterface(s)),
-                Err(NO_SUCH_ENTRY) => syscalls::sleep_thread(0),
-                Err(err) => return Err(err)
+                Err(KernelError::NoSuchEntry) => syscalls::sleep_thread(0),
+                Err(err) => Err(err)?
             };
         }
 	  }
 
-    pub fn get_service(&self, name: u64) -> Result<ClientSession, usize> {
+    pub fn get_service(&self, name: u64) -> Result<ClientSession, Error> {
 		    use ipc::Message;
         let mut buf = [0; 0x100];
 
@@ -36,7 +36,7 @@ impl IUserInterface {
 		    Ok(ClientSession(res.pop_handle_move()?))
     }
 
-    pub fn register_service(&self, name: u64, is_light: bool, max_handles: u32) -> Result<ServerPort, usize> {
+    pub fn register_service(&self, name: u64, is_light: bool, max_handles: u32) -> Result<ServerPort, Error> {
 		    use ipc::Message;
         let mut buf = [0; 0x100];
 

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -6,6 +6,7 @@ use alloc::prelude::*;
 use core::fmt::Write;
 use kfs_libkern::nr;
 pub use kfs_libkern::{MemoryInfo, MemoryPermissions};
+use error::KernelError;
 
 global_asm!("
 .intel_syntax noprefix
@@ -65,7 +66,7 @@ extern {
     fn syscall_inner(registers: &mut Registers);
 }
 
-unsafe fn syscall(nr: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize, arg6: usize) -> Result<(usize, usize, usize, usize), usize> {
+unsafe fn syscall(nr: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize, arg6: usize) -> Result<(usize, usize, usize, usize), KernelError> {
     let mut registers = Registers {
         eax: nr,
         ebx: arg1,
@@ -81,11 +82,11 @@ unsafe fn syscall(nr: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
     if registers.eax == 0 {
         Ok((registers.ebx, registers.ecx, registers.edx, registers.esi))
     } else {
-        Err(registers.eax)
+        Err(KernelError::from_syscall_ret(registers.eax as u32))
     }
 }
 
-pub fn query_memory(addr: usize) -> Result<(MemoryInfo, usize), usize> {
+pub fn query_memory(addr: usize) -> Result<(MemoryInfo, usize), KernelError> {
     let mut meminfo = MemoryInfo::default();
     let (pageinfo, ..) = unsafe {
         syscall(nr::QueryMemory, &mut meminfo as *mut _ as usize, 0, addr, 0, 0, 0)?
@@ -104,7 +105,7 @@ pub fn exit_process() -> ! {
 }
 
 /// Creates a thread in the current process.
-pub fn create_thread(ip: fn() -> !, _context: usize, sp: *const u8, _priority: u32, _processor_id: u32) -> Result<Thread, usize> {
+pub fn create_thread(ip: fn() -> !, _context: usize, sp: *const u8, _priority: u32, _processor_id: u32) -> Result<Thread, KernelError> {
     unsafe {
         let (out_handle, ..) = syscall(nr::CreateThread, ip as usize, _context, sp as _, _priority as _, _processor_id as _, 0)?;
         Ok(Thread(Handle::new(out_handle as _)))
@@ -112,7 +113,7 @@ pub fn create_thread(ip: fn() -> !, _context: usize, sp: *const u8, _priority: u
 }
 
 /// Starts the thread for the provided handle.
-pub fn start_thread(thread_handle: &Thread) -> Result<(), usize> {
+pub fn start_thread(thread_handle: &Thread) -> Result<(), KernelError> {
     unsafe {
         syscall(nr::StartThread, (thread_handle.0).0.get() as usize, 0, 0, 0, 0, 0)?;
         Ok(())
@@ -129,28 +130,28 @@ pub fn exit_thread() -> ! {
 }
 
 /// Sleeps for a specified amount of time, or yield thread.
-pub fn sleep_thread(nanos: usize) -> Result<(), usize> {
+pub fn sleep_thread(nanos: usize) -> Result<(), KernelError> {
     unsafe {
         syscall(nr::SleepThread, nanos, 0, 0, 0, 0, 0)?;
         Ok(())
     }
 }
 
-pub fn create_shared_memory(size: usize, myperm: MemoryPermissions, otherperm: MemoryPermissions) -> Result<SharedMemory, usize> {
+pub fn create_shared_memory(size: usize, myperm: MemoryPermissions, otherperm: MemoryPermissions) -> Result<SharedMemory, KernelError> {
     unsafe {
         let (out_handle, ..) = syscall(nr::CreateSharedMemory, size, myperm.bits() as _, otherperm.bits() as _, 0, 0, 0)?;
         Ok(SharedMemory(Handle::new(out_handle as _)))
     }
 }
 
-pub fn map_shared_memory(handle: &SharedMemory, addr: usize, size: usize, perm: MemoryPermissions) -> Result<(), usize> {
+pub fn map_shared_memory(handle: &SharedMemory, addr: usize, size: usize, perm: MemoryPermissions) -> Result<(), KernelError> {
     unsafe {
         syscall(nr::MapSharedMemory, (handle.0).0.get() as _, addr, size, perm.bits() as _, 0, 0)?;
         Ok(())
     }
 }
 
-pub fn unmap_shared_memory(handle: &SharedMemory, addr: usize, size: usize) -> Result<(), usize> {
+pub fn unmap_shared_memory(handle: &SharedMemory, addr: usize, size: usize) -> Result<(), KernelError> {
     unsafe {
         syscall(nr::UnmapSharedMemory, (handle.0).0.get() as _, addr, size, 0, 0, 0)?;
         Ok(())
@@ -158,56 +159,56 @@ pub fn unmap_shared_memory(handle: &SharedMemory, addr: usize, size: usize) -> R
 }
 
 // Not totally public because it's not safe to use directly
-pub(crate) fn close_handle(handle: u32) -> Result<(), usize> {
+pub(crate) fn close_handle(handle: u32) -> Result<(), KernelError> {
     unsafe {
         syscall(nr::CloseHandle, handle as _, 0, 0, 0, 0, 0)?;
         Ok(())
     }
 }
 
-pub fn wait_synchronization(handles: &[HandleRef], timeout_ns: Option<usize>) -> Result<usize, usize> {
+pub fn wait_synchronization(handles: &[HandleRef], timeout_ns: Option<usize>) -> Result<usize, KernelError> {
     unsafe {
         let (handleidx, ..) = syscall(nr::WaitSynchronization, handles.as_ptr() as _, handles.len(), timeout_ns.unwrap_or(usize::max_value()), 0, 0, 0)?;
         Ok(handleidx)
     }
 }
 
-pub fn connect_to_named_port(s: &str) -> Result<ClientSession, usize> {
+pub fn connect_to_named_port(s: &str) -> Result<ClientSession, KernelError> {
     unsafe {
         let (out_handle, ..) = syscall(nr::ConnectToNamedPort, s.as_ptr() as _, 0, 0, 0, 0, 0)?;
         Ok(ClientSession(Handle::new(out_handle as _)))
     }
 }
 
-pub fn send_sync_request_with_user_buffer(buf: &mut [u8], handle: &ClientSession) -> Result<(), usize> {
+pub fn send_sync_request_with_user_buffer(buf: &mut [u8], handle: &ClientSession) -> Result<(), KernelError> {
     unsafe {
         syscall(nr::SendSyncRequestWithUserBuffer, buf.as_ptr() as _, buf.len(), (handle.0).0.get() as _, 0, 0, 0)?;
         Ok(())
     }
 }
 
-pub fn output_debug_string(s: &str) -> Result<(), usize> {
+pub fn output_debug_string(s: &str) -> Result<(), KernelError> {
     unsafe {
         syscall(nr::OutputDebugString, s.as_ptr() as _, s.len(), 0, 0, 0, 0)?;
         Ok(())
     }
 }
 
-pub fn create_session(is_light: bool, unk: usize) -> Result<(ServerSession, ClientSession), usize> {
+pub fn create_session(is_light: bool, unk: usize) -> Result<(ServerSession, ClientSession), KernelError> {
     unsafe {
         let (serverhandle, clienthandle, ..) = syscall(nr::CreateSession, is_light as _, unk, 0, 0, 0, 0)?;
         Ok((ServerSession(Handle::new(serverhandle as _)), ClientSession(Handle::new(clienthandle as _))))
     }
 }
 
-pub fn accept_session(port: &ServerPort) -> Result<ServerSession, usize> {
+pub fn accept_session(port: &ServerPort) -> Result<ServerSession, KernelError> {
     unsafe {
         let (out_handle, ..) = syscall(nr::AcceptSession, (port.0).0.get() as _, 0, 0, 0, 0, 0)?;
         Ok(ServerSession(Handle::new(out_handle as _)))
     }
 }
 
-pub fn reply_and_receive_with_user_buffer(buf: &mut [u8], handles: &[HandleRef], replytarget: Option<HandleRef>, timeout: Option<usize>) -> Result<usize, usize>{
+pub fn reply_and_receive_with_user_buffer(buf: &mut [u8], handles: &[HandleRef], replytarget: Option<HandleRef>, timeout: Option<usize>) -> Result<usize, KernelError> {
     unsafe {
         let (idx, ..) = syscall(nr::ReplyAndReceiveWithUserBuffer, buf.as_ptr() as _, buf.len(), handles.as_ptr() as _, handles.len(), match replytarget {
             Some(s) => s.inner.get() as _,
@@ -217,35 +218,35 @@ pub fn reply_and_receive_with_user_buffer(buf: &mut [u8], handles: &[HandleRef],
     }
 }
 
-pub fn create_interrupt_event(irqnum: usize, flag: u32) -> Result<ReadableEvent, usize> {
+pub fn create_interrupt_event(irqnum: usize, flag: u32) -> Result<ReadableEvent, KernelError> {
     unsafe {
         let (out_handle, ..) = syscall(nr::CreateInterruptEvent, irqnum, flag as usize, 0, 0, 0, 0)?;
         Ok(ReadableEvent(Handle::new(out_handle as _)))
     }
 }
 
-pub fn create_port(max_sessions: u32, is_light: bool, name_ptr: &str) -> Result<(ClientPort, ServerPort), usize> {
+pub fn create_port(max_sessions: u32, is_light: bool, name_ptr: &str) -> Result<(ClientPort, ServerPort), KernelError> {
     unsafe {
         let (out_client_handle, out_server_handle, ..) = syscall(nr::CreatePort, max_sessions as _, is_light as _, name_ptr.as_ptr() as _, 0, 0, 0)?;
         Ok((ClientPort(Handle::new(out_client_handle as _)), ServerPort(Handle::new(out_server_handle as _))))
     }
 }
 
-pub fn manage_named_port(name: &str, max_handles: u32) -> Result<ServerPort, usize> {
+pub fn manage_named_port(name: &str, max_handles: u32) -> Result<ServerPort, KernelError> {
     unsafe {
         let (out_handle, ..) = syscall(nr::ManageNamedPort, name.as_ptr() as _, max_handles as _, 0, 0, 0, 0)?;
         Ok(ServerPort(Handle::new(out_handle as _)))
     }
 }
 
-pub fn connect_to_port(port: &ClientPort) -> Result<ClientSession, usize> {
+pub fn connect_to_port(port: &ClientPort) -> Result<ClientSession, KernelError> {
     unsafe {
         let (out_handle, ..) = syscall(nr::ConnectToPort, (port.0).0.get() as _, 0, 0, 0, 0, 0)?;
         Ok(ClientSession(Handle::new(out_handle as _)))
     }
 }
 
-pub fn map_framebuffer() -> Result<(&'static mut [u8], usize, usize, usize), usize> {
+pub fn map_framebuffer() -> Result<(&'static mut [u8], usize, usize, usize), KernelError> {
     unsafe {
         let (addr, width, height, bpp) = syscall(nr::MapFramebuffer, 0, 0, 0, 0, 0, 0)?;
         output_debug_string(&format!("{} {} {} {}", addr, width, height, bpp));

--- a/shell/src/vbe.rs
+++ b/shell/src/vbe.rs
@@ -11,6 +11,7 @@ use font_rs::{font, font::{Font, GlyphBitmap}};
 use spin::{Mutex, MutexGuard, Once};
 use hashmap_core::HashMap;
 use syscalls;
+use libuser::error::Error;
 
 /// A rgb color
 #[derive(Copy, Clone, Debug)]
@@ -35,7 +36,7 @@ impl Framebuffer {
     ///
     /// This function should only be called once, to ensure there is only a
     /// single mutable reference to the underlying framebuffer.
-    pub fn new() -> Result<Framebuffer, usize> {
+    pub fn new() -> Result<Framebuffer, Error> {
         let (buf, width, height, bpp) = syscalls::map_framebuffer()?;
 
         debug!("VBE vaddr: {:#010x}", buf.as_ptr() as usize);

--- a/vi/src/main.rs
+++ b/vi/src/main.rs
@@ -16,16 +16,7 @@ use libuser::ipc::server::{WaitableManager, PortHandler, IWaitable};
 use libuser::types::*;
 use hashmap_core::map::{HashMap, Entry};
 use spin::Mutex;
-
-enum Error {
-    None = 0
-}
-
-impl Into<usize> for Error {
-    fn into(self) -> usize {
-        ((self as usize) << 9) | 0x21
-    }
-}
+use libuser::error::{KernelError, Error};
 
 #[derive(Default)]
 struct ViInterface;
@@ -34,7 +25,7 @@ object! {
     impl ViInterface {
         // TODO: Take some transfer memory
         #[cmdid(0)]
-        fn create_buffer(&mut self, handle: Handle<copy>,) -> Result<(Handle,), usize> {
+        fn create_buffer(&mut self, handle: Handle<copy>,) -> Result<(Handle,), Error> {
             /*let sharedmem = SharedMemory::from_raw(handle);
             addr = find_vaddr();
             sharedmem.map(addr);
@@ -43,7 +34,7 @@ object! {
             };
             let (server, client) = syscalls::create_session(false, 0);
             //session = SessionWrapper::new();*/
-            Err(0xFC01)
+            Err(KernelError::PortRemoteDead.into())
         }
     }
 }


### PR DESCRIPTION
- Move kernel UserspaceError to libkern KernelError
- Create a libuser::error::Error type, strongly typing all the errors.
- Make all the libuser syscalls return a KernelError type
- Make all the wrapper return a fat Error type.