### PR TITLE
Fix find_virtual_space_aligned

### DIFF
--- a/kernel/src/paging/hierarchical_table.rs
+++ b/kernel/src/paging/hierarchical_table.rs
@@ -552,6 +552,10 @@ pub trait TableHierarchy {
                                             .checked_add(T::entry_vm_size())
                                             .and_then(|addr| align_up_checked(addr, alignment))
                                             .unwrap_or(usize::max_value());
+                        // if we're at the end of the address space, doing the arithmetic
+                        // would overflow. We catch this case, and make the hole's start_address
+                        // usize::max_value(). This case is then handled on the next iteration,
+                        // the checks will see that desired_length is no longer obtainable, and return.
                         hole.len = 0;
                     },
                     (_, PageState::Present(_)) => {

--- a/kernel/src/paging/hierarchical_table.rs
+++ b/kernel/src/paging/hierarchical_table.rs
@@ -548,8 +548,11 @@ pub trait TableHierarchy {
                     (0, PageState::Present(_)) | (_, PageState::Guarded) => {
                         // hole was not big enough :(
                         // start a new hole on the next aligned address
+                        hole.start_addr = (hole.start_addr + hole.len)
+                                            .checked_add(T::entry_vm_size())
+                                            .and_then(|addr| align_up_checked(addr, alignment))
+                                            .unwrap_or(usize::max_value());
                         hole.len = 0;
-                        hole.start_addr = hole.start_addr.saturating_add(alignment);
                     },
                     (_, PageState::Present(_)) => {
                         // we must look into child table


### PR DESCRIPTION
When the hole we were considering was too small, we should
continue searching from the end of the considered hole,
not restart searching in the same hole.