### PR TITLE
Fix enum_with_val Debug impl, fixes KernelError Debug being useless

### DIFF
--- a/libutils/src/lib.rs
+++ b/libutils/src/lib.rs
@@ -90,7 +90,7 @@ macro_rules! enum_with_val {
         impl ::core::fmt::Debug for $ident {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 match self {
-                    $(&$ident::$variant => f.write_str(stringify!($ident)),)*
+                    $(&$ident::$variant => write!(f, "{}::{}", stringify!($ident), stringify!($variant)),)*
                     &$ident(v) => write!(f, "UNKNOWN({})", v),
                 }
             }


### PR DESCRIPTION
enum_with_val used to only print the type in its debug implementation, omitting to print the variant. This is obviously totally useless. We now print the variant.