### PR TITLE
kernel: exception drops thread struct #whoopsie

### DIFF
--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -26,6 +26,11 @@ mod irq;
 mod syscalls;
 
 /// Checks if our thread was killed, in which case unschedule ourselves.
+///
+/// # Note
+///
+/// As this function will be the last that will be called by a thread before dying,
+/// caller must make sure all of its scope variables are ok to be leaked.
 pub fn check_thread_killed() {
     if scheduler::get_current_thread().state.load(Ordering::SeqCst) == ThreadState::Killed {
         let lock = SpinLockIRQ::new(());
@@ -51,25 +56,29 @@ fn panic_on_exception(exception_string: Arguments, exception_stack_frame: &Excep
 }
 
 extern "x86-interrupt" fn divide_by_zero_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Divide Error Exception"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Divide Error Exception"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Divide Error Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Divide Error Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn debug_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Debug Exception"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Debug Exception"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Debug Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Debug Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
@@ -84,49 +93,57 @@ extern "x86-interrupt" fn breakpoint_handler(_stack_frame: &mut ExceptionStackFr
 }
 
 extern "x86-interrupt" fn overflow_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Overflow Exception"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Overflow Exception"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Overflow Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Overflow Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn bound_range_exceeded_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("BOUND Range Exceeded Exception"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("BOUND Range Exceeded Exception"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("BOUND Range Exceeded Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("BOUND Range Exceeded Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Invalid opcode Exception"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Invalid opcode Exception"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Invalid opcode Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Invalid opcode Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn device_not_available_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Device Not Available Exception"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Device Not Available Exception"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Device Not Available Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Device Not Available Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
@@ -162,75 +179,87 @@ extern "x86-interrupt" fn invalid_tss_handler(stack_frame: &mut ExceptionStackFr
 }
 
 extern "x86-interrupt" fn segment_not_present_handler(stack_frame: &mut ExceptionStackFrame, errcode: u32) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Segment Not Present: error code: {:?}", errcode), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Segment Not Present: error code: {:?}", errcode), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Segment Not Present in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Segment Not Present in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn stack_segment_fault_handler(stack_frame: &mut ExceptionStackFrame, errcode: u32) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Stack Fault Exception: error code: {:?}", errcode), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Stack Fault Exception: error code: {:?}", errcode), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Exception : Stack Fault Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Exception : Stack Fault Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn general_protection_fault_handler(stack_frame: &mut ExceptionStackFrame, errcode: u32) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("General Protection Fault Exception: error code: {:?}", errcode), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("General Protection Fault Exception: error code: {:?}", errcode), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Exception : General Protection Fault Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Exception : General Protection Fault Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn page_fault_handler(stack_frame: &mut ExceptionStackFrame, errcode: PageFaultErrorCode) {
-    let cause_address = ::paging::read_cr2();
+    {
+        let cause_address = ::paging::read_cr2();
 
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Page Fault accessing {:?}, error: {:?}", cause_address, errcode), stack_frame);
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Page Fault accessing {:?}, error: {:?}", cause_address, errcode), stack_frame);
+        }
+
+        let thread = get_current_thread();
+        error!("Exception : Page Fault accessing {:?}, error: {:?} in {:#?}", cause_address, errcode, thread);
+        ProcessStruct::kill_process(thread.process.clone());
     }
-
-    let thread = get_current_thread();
-    warn!("Exception : Page Fault accessing {:?}, error: {:?} in {:#?}", cause_address, errcode, thread);
-    ProcessStruct::kill_process(thread.process.clone());
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn x87_floating_point_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("x87 FPU floating-point error"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("x87 FPU floating-point error"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("x87 FPU floating-point error in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("x87 FPU floating-point error in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn alignment_check_handler(stack_frame: &mut ExceptionStackFrame, errcode: u32) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Alignment Check Exception: error code: {:?}", errcode), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Alignment Check Exception: error code: {:?}", errcode), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Alignment Check Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Alignment Check Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
@@ -241,25 +270,29 @@ extern "x86-interrupt" fn machine_check_handler(stack_frame: &mut ExceptionStack
 }
 
 extern "x86-interrupt" fn simd_floating_point_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("SIMD Floating-Point Exception"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("SIMD Floating-Point Exception"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("SIMD Floating-Point Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("SIMD Floating-Point Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }
 
 extern "x86-interrupt" fn virtualization_handler(stack_frame: &mut ExceptionStackFrame) {
-    if cfg!(feature = "panic-on-exception") {
-        panic_on_exception(format_args!("Virtualization Exception"), stack_frame);
-    }
+    {
+        if cfg!(feature = "panic-on-exception") {
+            panic_on_exception(format_args!("Virtualization Exception"), stack_frame);
+        }
 
-    let thread = get_current_thread();
-    warn!("Virtualization Exception in {:#?}", thread);
-    ProcessStruct::kill_process(thread.process.clone());
+        let thread = get_current_thread();
+        error!("Virtualization Exception in {:#?}", thread);
+        ProcessStruct::kill_process(thread.process.clone());
+    }
 
     check_thread_killed();
 }


### PR DESCRIPTION
Exception handlers used to unschedule with some Arc strong references still in scope,
which had the effect of leaking them, and thread/process structs were never dropped.

Now the Arcs are in their own scope, and dropped before the call to unschedule.

Fixes #153