### PR TITLE
Add argument handling to start_thread syscall.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "kfs-libuser 0.1.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/kernel/src/interrupts/syscalls.rs
+++ b/kernel/src/interrupts/syscalls.rs
@@ -160,7 +160,7 @@ fn exit_thread() -> Result<(), UserspaceError> {
 /// # Params
 ///
 /// * `ip` the entry point of the thread,
-/// * `context` ignored,
+/// * `arg` the initial argument of the thread (passed in eax),
 /// * `sp` the top of the stack,
 /// * `priority` ignored,
 /// * `processor_id` ignored,
@@ -168,9 +168,9 @@ fn exit_thread() -> Result<(), UserspaceError> {
 /// # Returns
 ///
 /// A thread_handle to the created thread.
-fn create_thread(ip: usize, _context: usize, sp: usize, _priority: u32, _processor_id: u32) -> Result<usize, UserspaceError> {
+fn create_thread(ip: usize, arg: usize, sp: usize, _priority: u32, _processor_id: u32) -> Result<usize, UserspaceError> {
     let cur_proc = get_current_process();
-    let thread = ThreadStruct::new( &cur_proc, VirtualAddress(ip), VirtualAddress(sp))?;
+    let thread = ThreadStruct::new(&cur_proc, VirtualAddress(ip), VirtualAddress(sp), arg)?;
     let handle = Handle::Thread(thread);
     let mut handles_table = cur_proc.phandles.lock();
     Ok(handles_table.add_handle(Arc::new(handle)) as usize)

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -110,7 +110,7 @@ fn main() {
 
                 (VirtualAddress(ep), stack + 5 * PAGE_SIZE)
         };
-        let thread = ThreadStruct::new(&proc, ep, sp)
+        let thread = ThreadStruct::new(&proc, ep, sp, 0)
             .expect("failed creating thread for service");
         ThreadStruct::start(thread)
             .expect("failed starting thread for service");

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -113,6 +113,9 @@ pub struct ThreadStruct {
     ///
     /// Used by the SpinLockIRQ to implement recursive irqsave logic.
     pub int_disable_counter: AtomicUsize,
+
+    /// Argument passed to the entrypoint on first schedule.
+    pub arg: usize
 }
 
 /// A handle to a userspace-accessible resource.
@@ -505,7 +508,7 @@ impl ThreadStruct {
     ///
     /// The thread's only strong reference is stored in the process' maternity,
     /// and we return only a weak to it, that can directly be put in a thread_handle.
-    pub fn new(belonging_process: &Arc<ProcessStruct>, ep: VirtualAddress, stack: VirtualAddress) -> Result<Weak<Self>, KernelError> {
+    pub fn new(belonging_process: &Arc<ProcessStruct>, ep: VirtualAddress, stack: VirtualAddress, arg: usize) -> Result<Weak<Self>, KernelError> {
 
         // allocate its kernel stack
         let kstack = KernelStack::allocate_stack()?;
@@ -523,6 +526,7 @@ impl ThreadStruct {
                 hwcontext : empty_hwcontext,
                 int_disable_counter: AtomicUsize::new(0),
                 process: Arc::clone(belonging_process),
+                arg
             }
         );
 
@@ -595,6 +599,7 @@ impl ThreadStruct {
                 hwcontext,
                 int_disable_counter: AtomicUsize::new(0),
                 process: Arc::clone(&process),
+                arg: 0
             }
         );
 

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -134,9 +134,9 @@ pub fn exit_process() -> ! {
 }
 
 /// Creates a thread in the current process.
-pub fn create_thread(ip: fn() -> !, _context: usize, sp: *const u8, _priority: u32, _processor_id: u32) -> Result<Thread, KernelError> {
+pub fn create_thread(ip: extern fn() -> !, arg: usize, sp: *const u8, _priority: u32, _processor_id: u32) -> Result<Thread, KernelError> {
     unsafe {
-        let (out_handle, ..) = syscall(nr::CreateThread, ip as usize, _context, sp as _, _priority as _, _processor_id as _, 0)?;
+        let (out_handle, ..) = syscall(nr::CreateThread, ip as usize, arg, sp as _, _priority as _, _processor_id as _, 0)?;
         Ok(Thread(Handle::new(out_handle as _)))
     }
 }

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0 OR MIT"
 gif = { git = "https://github.com/roblabla/image-gif" }
 log = "0.4.6"
 kfs-libuser = { path = "../libuser" }
+spin = "0.5"
 
 [dependencies.byteorder]
 default-features = false

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -3,7 +3,7 @@
 //! Creates an interactive terminal window, providing a few functions useful to
 //! test KFS. Type help followed by enter to get a list of allowed commands.
 
-#![feature(alloc, asm)]
+#![feature(alloc, asm, naked_functions)]
 #![feature(const_let)]
 #![no_std]
 
@@ -19,6 +19,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate kfs_libuser as libuser;
 extern crate byteorder;
+extern crate spin;
 
 mod ps2;
 use libuser::io;
@@ -27,8 +28,10 @@ use libuser::window::{Window, Color};
 use libuser::terminal::{Terminal, WindowSize};
 
 use core::fmt::Write;
-use alloc::vec::Vec;
+use alloc::prelude::*;
+use alloc::sync::Arc;
 use byteorder::{ByteOrder, LE};
+use spin::Mutex;
 
 fn main() {
     let mut terminal = Terminal::new(WindowSize::FontLines(-1, false)).unwrap();
@@ -36,7 +39,7 @@ fn main() {
         match &*ps2::get_next_line(&mut terminal) {
             "gif3" => show_gif(&LOUIS3[..]),
             "gif4" => show_gif(&LOUIS4[..]),
-            //"test_threads" => test_threads(&mut terminal),
+            "test_threads" => terminal = test_threads(terminal),
             "test_divide_by_zero" => test_divide_by_zero(),
             "test_page_fault" => test_page_fault(),
             "connect" => {
@@ -88,40 +91,78 @@ fn show_gif(louis: &[u8]) {
     }
 }
 
-// TODO: Re-enable test_threads
-// BODY: Test threads has been disabled when VBELoggers were removed, as they
-// BODY: would need the ability to get the terminal via an argument somehow.
-/*
-fn test_threads() {
-
-    fn thread_a() {
+fn test_threads(terminal: Terminal) -> Terminal {
+    fn thread_a(terminal: usize) {
+        let terminal = unsafe {
+            Arc::from_raw(terminal as *const Mutex<Terminal>)
+        };
         for _ in 0..10 {
-            writeln!(&mut VBELogger, "A");
-            sleep_thread(0);
+            if let Some(mut lock) = terminal.try_lock() {
+                writeln!(lock, "A");
+            }
+            libuser::syscalls::sleep_thread(0);
         }
     }
 
-    fn thread_b() -> ! {
-        for _ in 0..10 {
-            writeln!(&mut VBELogger, "B");
-            sleep_thread(0);
+    fn thread_b(terminal: usize) -> ! {
+        // Wrap in a block to forcibly call Arc destructor before exiting the thread.
+        {
+            let terminal = unsafe {
+                Arc::from_raw(terminal as *const Mutex<Terminal>)
+            };
+            for _ in 0..10 {
+                if let Some(mut lock) = terminal.try_lock() {
+                    writeln!(lock, "B");
+                }
+                libuser::syscalls::sleep_thread(0);
+            }
         }
-        exit_thread()
+        libuser::syscalls::exit_thread()
+    }
+
+    #[naked]
+    extern fn function_wrapper() {
+        unsafe {
+            asm!("
+            push eax
+            call $0
+            " :: "i"(thread_b as *const u8) :: "intel");
+        }
     }
 
     const THREAD_STACK_SIZE: usize = 0x2000;
 
+    let mut terminal = Arc::new(Mutex::new(terminal));
     let stack = Box::new([0u8; THREAD_STACK_SIZE]);
     let sp = (Box::into_raw(stack) as *const u8).wrapping_offset(THREAD_STACK_SIZE as isize);
-    let ip = thread_b;
-    let thread_handle = create_thread(ip, 0, sp, 0, 0)
+    let ip : extern fn() -> ! = unsafe {
+        // Safety: This is changing the return type from () to !. It's safe. It
+        // sucks though. This is, yet again, an instance of "naked functions are
+        // fucking horrible".
+        // Also, fun fact about the Rust Type System. Every function has its own
+        // type, that's zero-sized. Those usually get casted automatically into
+        // fn() pointers, but of course transmute is special. So we need to help
+        // it a bit.
+        let fn_wrapper: extern fn() = function_wrapper;
+        core::mem::transmute(fn_wrapper)
+    };
+    let thread_handle = libuser::syscalls::create_thread(ip, Arc::into_raw(terminal.clone()) as usize, sp, 0, 0)
         .expect("svcCreateThread returned an error");
     thread_handle.start()
         .expect("svcStartThread returned an error");
 
     // thread is running b, run a meanwhile
-    thread_a();
-}*/
+    thread_a(Arc::into_raw(terminal.clone()) as usize);
+
+    // Wait for thread_b to terminate.
+    loop {
+        match Arc::try_unwrap(terminal) {
+            Ok(terminal) => break terminal.into_inner(),
+            Err(x) => terminal = x
+        }
+        libuser::syscalls::sleep_thread(0);
+    }
+}
 
 fn test_divide_by_zero() {
     // don't panic, we want to actually divide by zero


### PR DESCRIPTION
Re-enable the test_threads command from shell.
Some shenanigans were used to make it all work. The terminal is
passed by value to the test_threads function, which wraps it in
an Arc<Mutex> in order to share it between the two threads. Those
threads will then repeatedly try to lock it, and yield if they fail.
Yielding is important, since we lack preemption.

The argument is passed via EAX. This sucks because the C ABI expects
it on the stack, so we have to make a wrapper naked function that
pushes it... Maybe it should be the job of the kernel? On the other
hand, we're going to want a wrapper around test creation anyways.