### PR TITLE
Makefile: stop flooding log on every interrupt

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -178,7 +178,7 @@ workspace = false
 description = "Runs the bootable ISO in qemu with gdb support"
 dependencies = ["iso"]
 command = "qemu-system-i386"
-args = ["-cdrom", "os.iso", "-serial", "stdio", "-vnc", "${VNC_PORT}", "-no-reboot", "-gdb", "tcp::${GDB_PORT}", "-S", "-d", "int,cpu_reset"]
+args = ["-cdrom", "os.iso", "-serial", "stdio", "-vnc", "${VNC_PORT}", "-no-reboot", "-gdb", "tcp::${GDB_PORT}", "-S", "-d", "cpu_reset"]
 
 [tasks.doc]
 workspace = false


### PR DESCRIPTION
qemu's `-d int` was nice when we were trying to make interruption work,
but now it's become a real pain.