### PR TITLE
Syscalls physical memory

### DIFF
--- a/ahci/src/main.rs
+++ b/ahci/src/main.rs
@@ -46,6 +46,7 @@ capabilities!(CAPABILITIES = Capabilities {
         kfs_libuser::syscalls::nr::UnmapSharedMemory,
         kfs_libuser::syscalls::nr::ConnectToNamedPort,
         kfs_libuser::syscalls::nr::CreateInterruptEvent,
+        kfs_libuser::syscalls::nr::QueryPhysicalAddress,
     ],
     raw_caps: [
         kfs_libuser::caps::ioport(pci::CONFIG_ADDRESS + 0), kfs_libuser::caps::ioport(pci::CONFIG_ADDRESS + 1), kfs_libuser::caps::ioport(pci::CONFIG_ADDRESS + 2), kfs_libuser::caps::ioport(pci::CONFIG_ADDRESS + 3),

--- a/kernel/src/frame_allocator/physical_mem_region.rs
+++ b/kernel/src/frame_allocator/physical_mem_region.rs
@@ -228,22 +228,9 @@ mod test {
     use crate::paging::PAGE_SIZE;
 
     #[test]
-    #[should_panic]
     fn on_fixed_mmio_checks_reserved() {
         let _f = crate::frame_allocator::init();
-        unsafe { PhysicalMemRegion::on_fixed_mmio(PhysicalAddress(0x00000000), PAGE_SIZE) };
-    }
-
-    #[test]
-    fn on_fixed_mmio_rounds_unaligned() {
-        let _f = crate::frame_allocator::init();
-        // reserve them so we don't panic
-        crate::frame_allocator::mark_frame_bootstrap_allocated(PhysicalAddress(0));
-        crate::frame_allocator::mark_frame_bootstrap_allocated(PhysicalAddress(PAGE_SIZE));
-
-        let region = unsafe { PhysicalMemRegion::on_fixed_mmio(PhysicalAddress(0x00000007), PAGE_SIZE + 1) };
-        assert_eq!(region.start_addr, 0);
-        assert_eq!(region.frames, 2);
+        unsafe { PhysicalMemRegion::on_fixed_mmio(PhysicalAddress(0x00000000), PAGE_SIZE) }.unwrap_err();
     }
 
     #[test]

--- a/kernel/src/interrupts/syscalls.rs
+++ b/kernel/src/interrupts/syscalls.rs
@@ -48,7 +48,7 @@ fn map_framebuffer() -> Result<(usize, usize, usize, usize), UserspaceError> {
                                 * tag.framebuffer_dimensions().0 as usize
                                 * tag.framebuffer_dimensions().1 as usize / 8;
     let frame_buffer_phys_region = unsafe {
-        PhysicalMemRegion::on_fixed_mmio(PhysicalAddress(tag.framebuffer_addr()), framebuffer_size)
+        PhysicalMemRegion::on_fixed_mmio(PhysicalAddress(tag.framebuffer_addr()), framebuffer_size)?
     };
 
     let process = get_current_process();

--- a/kernel/src/interrupts/syscalls.rs
+++ b/kernel/src/interrupts/syscalls.rs
@@ -111,11 +111,28 @@ fn create_interrupt_event(irq_num: usize, _flag: u32) -> Result<usize, Userspace
 /// 1. 0x00000000 (On Horizon it contains the KernelSpace virtual address of this mapping,
 ///    but I don't see any use for it).
 /// 2. The length of the physical region.
+// kfs extension
+/// 3. The offset in the region of the given virtual address.
 ///
 /// # Error
 ///
 /// - InvalidAddress: This address does not map physical memory.
-fn query_physical_address(virtual_address: usize) -> Result<(usize, usize, usize), UserspaceError> {
+// TODO: Kernel mappings must be physically continuous.
+// BODY: Virtual memory is a great thing, it can make a fragmented mapping appear contiguous from the
+// BODY: userspace. But unfortunately Horizon does not take advantage of this feature, and
+// BODY: allocates its mapping as a single Physical Memory Region.
+// BODY:
+// BODY: Its syscalls are based around that fact, and to do a `virt_to_phys(addr)`, you simply
+// BODY: need to `query_memory(addr).offset` to get its offset in its mapping, and compute its
+// BODY: physical address as `query_physical_address(addr).base + offset`.
+// BODY:
+// BODY: This will not work when the mapping is composed of several physical regions, and
+// BODY: Horizon drivers will not be expecting that. So for them to work on our kernel, we must
+// BODY: renounce using fragmented mappings.
+// BODY:
+// BODY: For now `query_physical_address` is providing an additional "offset in physical region" return value,
+// BODY: to help KFS drivers doing a virt_to_phys without needing to walk the list of physical regions.
+fn query_physical_address(virtual_address: usize) -> Result<(usize, usize, usize, usize), UserspaceError> {
     let virtual_address = VirtualAddress(virtual_address);
     let proc = scheduler::get_current_process();
     let mem = proc.pmemory.lock();
@@ -130,7 +147,7 @@ fn query_physical_address(virtual_address: usize) -> Result<(usize, usize, usize
     let mut i = 0;
     let pos = frames.iter().position(|region| { i += region.size(); i > offset })
         .expect("Mapping region count is corrupted");
-    Ok((frames[pos].address().addr(), 0x00000000, frames[pos].size()))
+    Ok((frames[pos].address().addr(), 0x00000000, frames[pos].size(), offset - (i - frames[pos].size())))
 }
 
 /// Waits for one of the handles to signal an event.
@@ -665,7 +682,7 @@ pub extern fn syscall_handler_inner(registers: &mut Registers) {
         (true, nr::ReplyAndReceiveWithUserBuffer) => registers.apply1(reply_and_receive_with_user_buffer(UserSpacePtrMut::from_raw_parts_mut(x0 as _, x1), UserSpacePtr::from_raw_parts(x2 as _, x3), x4 as _, x5)),
         (true, nr::CreateSharedMemory) => registers.apply1(create_shared_memory(x0 as _, x1 as _, x2 as _)),
         (true, nr::CreateInterruptEvent) => registers.apply1(create_interrupt_event(x0, x1 as u32)),
-        (true, nr::QueryPhysicalAddress) => registers.apply3(query_physical_address(x0 as _)),
+        (true, nr::QueryPhysicalAddress) => registers.apply4(query_physical_address(x0 as _)),
         (true, nr::CreatePort) => registers.apply2(create_port(x0 as _, x1 != 0, UserSpacePtr(x2 as _))),
         (true, nr::ManageNamedPort) => registers.apply1(manage_named_port(UserSpacePtr(x0 as _), x1 as _)),
         (true, nr::ConnectToPort) => registers.apply1(connect_to_port(x0 as _)),

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -492,7 +492,7 @@ impl ProcessStruct {
 impl Drop for ProcessStruct {
     fn drop(&mut self) {
         // todo this should be a debug !
-        info!("Dropped a process : {:?}", self)
+        info!("☠️ Dropped a process : {}", self.name)
     }
 }
 
@@ -661,7 +661,7 @@ impl ThreadStruct {
 impl Drop for ThreadStruct {
     fn drop(&mut self) {
         // todo this should be a debug !
-        info!("Dropped a thread : {:?}", self)
+        info!("💀 Dropped a thread : {}", self.process.name)
     }
 }
 

--- a/kernel/src/process/capabilities.rs
+++ b/kernel/src/process/capabilities.rs
@@ -199,13 +199,14 @@ impl ProcessCapabilities {
                     duplicate_svc.set_bit(index as _, true);
                     let index = index as usize * 24;
                     // This cannot overflow: The first 8 bit are guaranteed to be 0.
-                    let highest_svc_in_mask = 24 - (mask.leading_zeros() as usize - 8);
-                    if index + highest_svc_in_mask > MAX_SVC {
-                        return Err(KernelError::ExceedingMaximum {
-                            maximum: MAX_SVC as u64,
-                            value: (index + highest_svc_in_mask) as u64,
-                            backtrace: Backtrace::new()
-                        });
+                    if let Some(highest_svc_in_mask) = 23usize.checked_sub(mask.leading_zeros() as usize - 8) {
+                        if index + highest_svc_in_mask > MAX_SVC {
+                            return Err(KernelError::ExceedingMaximum {
+                                maximum: MAX_SVC as u64,
+                                value: (index + highest_svc_in_mask) as u64,
+                                backtrace: Backtrace::new()
+                            });
+                        }
                     }
                     capabilities.syscall_mask.set_bits(index..index + 24, mask);
                 }

--- a/libkern/src/lib.rs
+++ b/libkern/src/lib.rs
@@ -146,8 +146,9 @@ macro_rules! syscalls {
     (
         static $byname:ident;
         mod $byid:ident;
-        maxid = $maxid:expr;
-        $($name:ident = $id:expr),* $(,)*
+        $($name:ident = $id:expr,)*
+        ---
+        $max_svc_ident:ident = $max_svc_id:expr
     ) => {
         pub mod $byid {
             //! Syscall numbers
@@ -161,12 +162,15 @@ macro_rules! syscalls {
                 #[allow(non_upper_case_globals)]
                 pub const $name: usize = $id;
             )*
+
+            #[allow(non_upper_case_globals)]
+            pub const $max_svc_ident: usize = $max_svc_id;
         }
         lazy_static! {
             /// A table associating a syscall name string for every syscall
             /// number.
-            pub static ref $byname: [&'static str; $maxid] = {
-                let mut arr = ["Unknown"; $maxid];
+            pub static ref $byname: [&'static str; $max_svc_id + 1] = {
+                let mut arr = ["Unknown"; $max_svc_id + 1];
                 $(arr[$id] = stringify!($name);)*
                 arr
             };
@@ -177,7 +181,6 @@ macro_rules! syscalls {
 syscalls! {
     static SYSCALL_NAMES;
     mod nr;
-    maxid = 0x82;
     SetHeapSize = 0x01,
     SetMemoryPermission = 0x02,
     SetMemoryAttribute = 0x03,
@@ -299,6 +302,7 @@ syscalls! {
     MapFramebuffer = 0x80,
     StartProcessEntrypoint = 0x81,
 
+    ---
     // Add SVCs before this line.
     MaxSvc = 0x81
 }

--- a/libkern/src/lib.rs
+++ b/libkern/src/lib.rs
@@ -301,8 +301,9 @@ syscalls! {
     // KFS Extensions
     MapFramebuffer = 0x80,
     StartProcessEntrypoint = 0x81,
+    MapMmioRegion = 0x82,
 
     ---
     // Add SVCs before this line.
-    MaxSvc = 0x81
+    MaxSvc = 0x82
 }

--- a/libuser/src/mem.rs
+++ b/libuser/src/mem.rs
@@ -1,0 +1,76 @@
+//! Memory
+//!
+//! Low-level helpers to assist memory mapping, MMIOs and DMAs.
+
+use kfs_libutils::{align_down, align_up};
+use crate::syscalls;
+use crate::error::{KernelError, LibuserError, Error};
+
+/// The size of page. Used to interface with the kernel.
+pub const PAGE_SIZE: usize = 4096;
+
+/// Finds a free memory zone of the given size and alignment in the current
+/// process's virtual address space. Note that the address space is not reserved,
+/// a call to map_memory to that address space might fail if another thread
+/// maps to it first. It is recommended to use this function and the map syscall
+/// in a loop.
+///
+/// # Panics
+///
+/// Panics on underflow when size = 0.
+///
+/// Panics on underflow when align = 0.
+pub fn find_free_address(size: usize, align: usize) -> Result<usize, Error> {
+    let mut addr = 0;
+    // Go over the address space.
+    loop {
+        let (meminfo, _) = syscalls::query_memory(addr)?;
+        if meminfo.memtype == kfs_libkern::MemoryType::Unmapped {
+            let alignedbaseaddr = kfs_libutils::align_up_checked(meminfo.baseaddr, align).ok_or(LibuserError::AddressSpaceExhausted)?;
+
+            let alignment = alignedbaseaddr - meminfo.baseaddr;
+            if alignment.checked_add(size - 1).ok_or(LibuserError::AddressSpaceExhausted)? < meminfo.size {
+                return Ok(alignedbaseaddr)
+            }
+        }
+        addr = meminfo.baseaddr.checked_add(meminfo.size).ok_or(LibuserError::AddressSpaceExhausted)?;
+    }
+}
+
+/// Maps a Mmio struct in the virtual memory of this process.
+///
+/// This function preserves the offset relative to `PAGE_SIZE`.
+///
+/// # Example
+///
+/// ```
+///     /// Found at physical address 0xabc00030
+///     #[repr(packed)]
+///     struct DeviceFoo {
+///         header: Mmio<u32>,
+///         version: Mmio<u32>,
+///         field_a: Mmio<u16>
+///         field_b: Mmio<u16>
+///     }
+///
+///     let mapped_data: *mut DeviceFoo = map_mmio::<DeviceFoo>(0xabc00030); // = virtual address 0x7030
+///     assert_eq!(mapped_data.version.read(), 0x010200);
+/// ```
+pub fn map_mmio<T>(physical_address: usize) -> Result<*mut T, KernelError> {
+    let aligned_phys_addr = align_down(physical_address, PAGE_SIZE);
+    let full_size = align_up(aligned_phys_addr + ::core::mem::size_of::<T>(), PAGE_SIZE) - aligned_phys_addr;
+    let virt_addr = find_free_address(full_size as _, 1).unwrap();
+    syscalls::map_mmio_region(aligned_phys_addr as _, full_size as _, virt_addr, true)?;
+    Ok((virt_addr + (physical_address % PAGE_SIZE)) as *mut T)
+}
+
+/// Gets the physical address of a structure from its virtual address, preserving offset in the page.
+///
+/// # Panics
+///
+/// * query_physical_address failed.
+pub fn virt_to_phys<T>(virtual_address: *const T) -> usize {
+    let (phys_region_start, _, _, phys_region_offset) = syscalls::query_physical_address(virtual_address as usize)
+        .expect("syscall query_physical_memory failed");
+    phys_region_start + phys_region_offset
+}

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -376,14 +376,16 @@ pub fn create_interrupt_event(irqnum: usize, flag: u32) -> Result<ReadableEvent,
 /// 1. 0x00000000 (On Horizon it contains the KernelSpace virtual address of this mapping,
 ///    but I don't see any use for it).
 /// 2. The length of the physical region.
+// kfs extension
+/// 3. The offset in the region of the given virtual address.
 ///
 /// # Error
 ///
 /// - InvalidAddress: This address does not map physical memory.
-pub fn query_physical_address(virtual_address: usize) -> Result<(usize, usize, usize), KernelError> {
+pub fn query_physical_address(virtual_address: usize) -> Result<(usize, usize, usize, usize), KernelError> {
     unsafe {
-        let (phys_addr, kernel_addr, phys_len, ..) = syscall(nr::QueryPhysicalAddress, virtual_address, 0, 0, 0, 0, 0)?;
-        Ok((phys_addr, kernel_addr, phys_len))
+        let (phys_addr, kernel_addr, phys_len, offset, ..) = syscall(nr::QueryPhysicalAddress, virtual_address, 0, 0, 0, 0, 0)?;
+        Ok((phys_addr, kernel_addr, phys_len, offset))
     }
 }
 

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -365,6 +365,28 @@ pub fn create_interrupt_event(irqnum: usize, flag: u32) -> Result<ReadableEvent,
     }
 }
 
+/// Gets the physical region a given virtual address maps.
+///
+/// This syscall is mostly used for DMAs, where the physical address of a buffer needs to be known
+/// by userspace.
+///
+/// # Return
+///
+/// 0. The start address of the physical region.
+/// 1. 0x00000000 (On Horizon it contains the KernelSpace virtual address of this mapping,
+///    but I don't see any use for it).
+/// 2. The length of the physical region.
+///
+/// # Error
+///
+/// - InvalidAddress: This address does not map physical memory.
+pub fn query_physical_address(virtual_address: usize) -> Result<(usize, usize, usize), KernelError> {
+    unsafe {
+        let (phys_addr, kernel_addr, phys_len, ..) = syscall(nr::QueryPhysicalAddress, virtual_address, 0, 0, 0, 0, 0)?;
+        Ok((phys_addr, kernel_addr, phys_len))
+    }
+}
+
 /// Creates an anonymous port.
 pub fn create_port(max_sessions: u32, is_light: bool, name_ptr: &str) -> Result<(ClientPort, ServerPort), KernelError> {
     unsafe {

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -397,3 +397,21 @@ pub fn map_framebuffer() -> Result<(&'static mut [u8], usize, usize, usize), Ker
         Ok((slice::from_raw_parts_mut(addr as *mut u8, framebuffer_size), width, height, bpp))
     }
 }
+
+/// Maps a physical region in the address space of the process.
+///
+/// # Errors
+///
+/// * InvalidAddress:
+///     * `virtual_address` is already occupied.
+///     * `virtual_address` is not PAGE_SIZE aligned.
+///     * `physical_address` points to a physical region in DRAM (it's not MMIO).
+/// * InvalidLength:
+///     * `length` is not PAGE_SIZE aligned.
+///     * `length` is zero.
+pub fn map_mmio_region(physical_address: usize, size: usize, virtual_address: usize, writable: bool) -> Result<(), KernelError> {
+    unsafe {
+        syscall(nr::MapMmioRegion, physical_address, size, virtual_address, writable as usize, 0, 0)?;
+        Ok(())
+    }
+}

--- a/libuser/src/window.rs
+++ b/libuser/src/window.rs
@@ -5,6 +5,7 @@
 use crate::types::{SharedMemory, MappedSharedMemory};
 use crate::vi::{ViInterface, IBuffer};
 use crate::syscalls::MemoryPermissions;
+use crate::mem::{find_free_address, PAGE_SIZE};
 use kfs_libutils::align_up;
 use crate::error::Error;
 use core::slice;
@@ -55,9 +56,9 @@ impl Window {
         let bpp = 32;
         let size = height * width * bpp / 8;
 
-        let sharedmem = SharedMemory::new(align_up(size, 0x1000) as _, MemoryPermissions::READABLE | MemoryPermissions::WRITABLE, MemoryPermissions::READABLE)?;
-        let addr = crate::find_free_address(size as _, 0x1000)?;
-        let buf = sharedmem.map(addr, align_up(size as _, 0x1000), MemoryPermissions::READABLE | MemoryPermissions::WRITABLE)?;
+        let sharedmem = SharedMemory::new(align_up(size, PAGE_SIZE as _) as _, MemoryPermissions::READABLE | MemoryPermissions::WRITABLE, MemoryPermissions::READABLE)?;
+        let addr = find_free_address(size as _, PAGE_SIZE)?;
+        let buf = sharedmem.map(addr, align_up(size as _, PAGE_SIZE), MemoryPermissions::READABLE | MemoryPermissions::WRITABLE)?;
         let handle = vi.create_buffer(buf.as_shared_mem(), top, left, width, height)?;
 
         let mut fb = Window {

--- a/vi/src/main.rs
+++ b/vi/src/main.rs
@@ -42,6 +42,7 @@ use spin::Mutex;
 use crate::libuser::error::Error;
 use crate::libuser::syscalls::MemoryPermissions;
 use kfs_libutils::align_up;
+use libuser::mem::{find_free_address, PAGE_SIZE};
 
 /// Entry point interface.
 #[derive(Default, Debug)]
@@ -59,8 +60,8 @@ object! {
         #[cmdid(0)]
         fn create_buffer(&mut self, manager: &WaitableManager, handle: Handle<copy>, top: i32, left: i32, width: u32, height: u32,) -> Result<(Handle,), Error> {
             let sharedmem = SharedMemory(handle);
-            let size = align_up(width * height * 4, 0x1000);
-            let addr = libuser::find_free_address(size as _, 0x1000)?;
+            let size = align_up(width * height * 4, PAGE_SIZE as _);
+            let addr = find_free_address(size as _, PAGE_SIZE)?;
             let mapped = sharedmem.map(addr, size as _, MemoryPermissions::READABLE)?;
             let buf = IBuffer {
                 buffer: Arc::new(Buffer {


### PR DESCRIPTION
- syscall MapMmioRegion
- syscall QueryPhysicalAddress
- moving some memory related functions of libuser in their own `mem` module
- improving the syscalls macro
- fixing the capabilities macro