### PR TITLE
shell: test_page_fault asm

### DIFF
--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -199,8 +199,13 @@ fn test_divide_by_zero() {
 
 /// Test function ensuring pagefaults kills only the current process.
 fn test_page_fault() {
-    let ptr: *const u8 = core::ptr::null();
-    let _res = unsafe { *ptr };
+    // dereference the null pointer.
+    // doing this in rust is so UB, it's optimized out, so we do it in asm.
+    unsafe {
+        asm!("
+        mov al, [0]
+        " ::: "eax" : "volatile", "intel")
+    }
 }
 
 /// Meme for KFS1


### PR DESCRIPTION
Rewrote the test_page_fault function in asm, because rust
used to optimize it out since it is extremely UB.

Fixes #223

I went and checked in GDB, and @roblabla was right, the match branch
was never taken, but instead we ended up in weird places.

Now it seems to be working... well, crashing ... well, doing what we expect.